### PR TITLE
Update the Docker docs 

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -19,6 +19,7 @@ DateTime
 Ducati
 FOF
 FOREACH
+Falkor
 FalkorDB
 FalkorDB's
 FalkorDBQAChain

--- a/bolt_support.md
+++ b/bolt_support.md
@@ -4,9 +4,9 @@ nav_order: 10
 description: "Connecting to FalkorDB using BOLT protocol."
 ---
 
-## BOLT protocol support for FalkorDB
+## [EXPERIMENTAL] BOLT protocol support for FalkorDB 
 
-FalkorDB provides support for querying using BOLT drivers.
+FalkorDB provides an experimental support for querying using BOLT drivers.
 This guide will walk you through the process of connecting to FalkorDB using the [BOLT protocol](https://en.wikipedia.org/wiki/Bolt_(network_protocol))
 
 ### Prerequisites
@@ -15,7 +15,7 @@ Before you begin, ensure that you have a FalkorDB instance up and running.
 You can use our Docker image for this purpose.
 
 ```bash
-docker run -p 6379:6379 -p7678:7678 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="BOLT_PORT 7678" --rm falkordb/falkordb:edge
+docker run -p 6379:6379 -p 7678:7678 -p 3000:3000 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="BOLT_PORT 7678" --rm falkordb/falkordb:edge
 ```
 
 Additionally, install the necessary BOLT drivers:

--- a/bolt_support.md
+++ b/bolt_support.md
@@ -18,6 +18,11 @@ You can use our Docker image for this purpose.
 docker run -p 6379:6379 -p 7678:7678 -p 3000:3000 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="BOLT_PORT 7678" --rm falkordb/falkordb:latest
 ```
 
+#### Ports 
+- 6379 - FalkorDB
+- 7678 - Bolt
+- 3000 - Falkor-Browser
+
 Additionally, install the necessary BOLT drivers:
 
 ```bash

--- a/bolt_support.md
+++ b/bolt_support.md
@@ -15,7 +15,7 @@ Before you begin, ensure that you have a FalkorDB instance up and running.
 You can use our Docker image for this purpose.
 
 ```bash
-docker run -p 6379:6379 -p 7678:7678 -p 3000:3000 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="BOLT_PORT 7678" --rm falkordb/falkordb:edge
+docker run -p 6379:6379 -p 7678:7678 -p 3000:3000 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="BOLT_PORT 7678" --rm falkordb/falkordb:latest
 ```
 
 Additionally, install the necessary BOLT drivers:

--- a/bolt_support.md
+++ b/bolt_support.md
@@ -7,6 +7,7 @@ description: "Connecting to FalkorDB using BOLT protocol."
 ## [EXPERIMENTAL] BOLT protocol support for FalkorDB 
 
 FalkorDB provides an experimental support for querying using BOLT drivers.
+We intend to extend the support in the future versions, the current version is not meant to be used in production.
 This guide will walk you through the process of connecting to FalkorDB using the [BOLT protocol](https://en.wikipedia.org/wiki/Bolt_(network_protocol))
 
 ### Prerequisites

--- a/configuration.md
+++ b/configuration.md
@@ -39,7 +39,7 @@ $ redis-server --loadmodule ./falkordb.so [OPT VAL]...
 When running a docker container
 
 ```sh
-docker run -p 6379:6379 -it -e FALKORDB_ARGS="[OPT VAL]" --rm falkordb/falkordb:edge
+docker run -p 6379:6379 -p 3000:3000 -it -e FALKORDB_ARGS="[OPT VAL]" --rm falkordb/falkordb:latest
 ```
 
 ## Setting configuration parameters at run-time (for supported parameters)

--- a/configuration.md
+++ b/configuration.md
@@ -11,7 +11,7 @@ Some of these parameters can only be set at load-time, while other parameters ca
 For example the following will run the server with global authentication password and 4 threads.
 
 ```sh
-docker run -p 6379:6379 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="THREAD_COUNT 4" --rm falkordb/falkordb:edge
+docker run -p 6379:6379 -p 3000:3000 -it -e REDIS_ARGS="--requirepass falkordb" -e FALKORDB_ARGS="THREAD_COUNT 4" --rm falkordb/falkordb:latest
 ```
 
 ## Setting configuration parameters on module load

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ FalkorDB is a blazing fast graph database used for low latency & high throughput
 Launch an instance using docker, or use our [sandbox](https://cloud.falkordb.com/sandbox)
 
 ```sh
-docker run -p 6379:6379 -it --rm falkordb/falkordb:latest
+docker run -p 6379:6379 -p 3000:3000 -it --rm falkordb/falkordb:latest
 ```
 
 Once loaded you can interact with FalkorDB using any of the supported [client libraries](/clients)


### PR DESCRIPTION
1. Add browser port
2. Mark Bolt as experimental
3. Use the latest not edge tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced experimental support for the BOLT protocol in FalkorDB, with a new port (3000) now exposed for BOLT communication.
- **Documentation**
	- Updated Docker run commands across documentation to include the new port mapping `-p 3000:3000`.
	- Updated Docker image version tag from `edge` to `latest` in configuration instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->