### PR TITLE
fix helm entry, use replica rather than slave, k8s_support.md

### DIFF
--- a/k8s_support.md
+++ b/k8s_support.md
@@ -37,6 +37,7 @@ replica:
   extraFlags:
   - "--loadmodule /FalkorDB/bin/linux-x64-release/src/falkordb.so"
 ```
+
 This file specify the FalkorDB image(you can choose different tags)
 and configure the master and slave to load the FalkorDB module.
 For additional configurations [see the official Helm chart documentation](https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml)

--- a/k8s_support.md
+++ b/k8s_support.md
@@ -33,7 +33,7 @@ master:
   extraFlags:
   - "--loadmodule /FalkorDB/bin/linux-x64-release/src/falkordb.so"
 
-slave:
+replica:
   extraFlags:
   - "--loadmodule /FalkorDB/bin/linux-x64-release/src/falkordb.so"
 ```


### PR DESCRIPTION
Follow https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml#L633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated terminology: Renamed `slave` configuration to `replica` in Kubernetes support documentation for better clarity and inclusivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->