### PR TITLE
Remove RedisGraph from different places

### DIFF
--- a/commands/graph.constraint-create.md
+++ b/commands/graph.constraint-create.md
@@ -134,7 +134,7 @@ redis> GRAPH.CONSTRAINT CREATE g UNIQUE NODE Person PROPERTIES 2 first_name last
 PENDING
 ```
 
-Since RedisGraph 2.12 indexes are constructed asynchronously. The constraint construction will start once the index is fully constructed.
+Since v2.12 indexes are constructed asynchronously. The constraint construction will start once the index is fully constructed.
 
 ### Creating a mandatory constraint for a relationship type
 

--- a/configuration.md
+++ b/configuration.md
@@ -75,9 +75,9 @@ The following table summarizes which configuration parameters can be set at modu
 | [NODE_CREATION_BUFFER](#node_creation_buffer)                | V | X |
 | [BOLT_PORT](#bolt_port)                                      | V | X |
 | [MAX_QUEUED_QUERIES](#max_queued_queries)                    | V | V |
-| [TIMEOUT](#timeout) (deprecated in RedisGraph v2.10)         | V | V |
-| [TIMEOUT_MAX](#timeout_max) (since RedisGraph v2.10)         | V | V |
-| [TIMEOUT_DEFAULT](#timeout_default) (since RedisGraph v2.10) | V | V |
+| [TIMEOUT](#timeout) (deprecated in v2.10)         | V | V |
+| [TIMEOUT_MAX](#timeout_max) (since v2.10)         | V | V |
+| [TIMEOUT_DEFAULT](#timeout_default) (since v2.10) | V | V |
 | [RESULTSET_SIZE](#resultset_size)                            | V | V |
 | [QUERY_MEM_CAPACITY](#query_mem_capacity)                    | V | V |
 | [VKEY_MAX_ENTITY_COUNT](#vkey_max_entity_count)              | V | V |
@@ -204,8 +204,8 @@ The `TIMEOUT` query parameter of the `GRAPH.QUERY`, `GRAPH.RO_QUERY`, and `GRAPH
 
 #### Default
 
-- Before RedisGraph v2.10: `TIMEOUT` is off (set to `0`).
-- Since RedisGraph v2.10: `TIMEOUT` is not specified; `TIMEOUT_MAX` and `TIMEOUT_DEFAULT` are specified instead.
+- Before v2.10: `TIMEOUT` is off (set to `0`).
+- Since v2.10: `TIMEOUT` is not specified; `TIMEOUT_MAX` and `TIMEOUT_DEFAULT` are specified instead.
 
 #### Example
 
@@ -217,7 +217,7 @@ $ redis-server --loadmodule ./falkordb.so TIMEOUT 1000
 
 ### TIMEOUT_MAX
 
-(Since RedisGraph v2.10)
+(Since v2.10)
 
 The `TIMEOUT_MAX` configuration parameter specifies the maximum execution time for both read and write queries, in milliseconds.
 
@@ -227,8 +227,8 @@ When a query execution time exceeds the maximal execution time, the query is abo
 
 #### Default
 
-- Before RedisGraph v2.10: unspecified and unsupported.
-- Since RedisGraph v2.10: `TIMEOUT_MAX` is off (set to `0`).
+- Before v2.10: unspecified and unsupported.
+- Since v2.10: `TIMEOUT_MAX` is off (set to `0`).
 
 #### Example
 
@@ -240,7 +240,7 @@ $ redis-server --loadmodule ./falkordb.so TIMEOUT_MAX 1000
 
 ### TIMEOUT_DEFAULT
 
-(Since RedisGraph v2.10)
+(Since v2.10)
 
 The `TIMEOUT_DEFAULT` configuration parameter specifies the default maximal execution time for both read and write queries, in milliseconds.
 
@@ -248,8 +248,8 @@ For a given query, this default maximal execution time can be overridden by the 
 
 #### Default
 
-- Before RedisGraph v2.10: unspecified and unsupported.
-- Since RedisGraph v2.10: `TIMEOUT_DEFAULT` is equal to `TIMEOUT_MAX` (set to `0`).
+- Before v2.10: unspecified and unsupported.
+- Since v2.10: `TIMEOUT_DEFAULT` is equal to `TIMEOUT_MAX` (set to `0`).
 
 #### Example
 
@@ -343,11 +343,11 @@ A number within the range [0, 1000]
 
 ### Query Timeout
 
-- Before RedisGraph v2.10, or if `TIMEOUT_DEFAULT` and `TIMEOUT_MAX` are not specified:
+- Before v2.10, or if `TIMEOUT_DEFAULT` and `TIMEOUT_MAX` are not specified:
 
   `TIMEOUT` allows overriding the `TIMEOUT` configuration parameter for a single read query. Write queries do not timeout.
 
-- Since RedisGraph v2.10, if either `TIMEOUT_DEFAULT` or `TIMEOUT_MAX` are specified:
+- Since v2.10, if either `TIMEOUT_DEFAULT` or `TIMEOUT_MAX` are specified:
 
   `TIMEOUT` allows overriding the `TIMEOUT_DEFAULT` configuration parameter value for a single `GRAPH.QUERY`, `GRAPH.RO_QUERY`, or `GRAPH.PROFILE` command. The `TIMEOUT` value cannot exceed the `TIMEOUT_MAX` value (the command would abort with a `(error) The query TIMEOUT parameter value cannot exceed the TIMEOUT_MAX configuration parameter value` reply).
 

--- a/design/client_spec.md
+++ b/design/client_spec.md
@@ -32,7 +32,7 @@ Instructions on how to efficiently convert these IDs in the [Procedure Calls](#p
 
 Additionally, two enums are exposed:
 
-[ColumnType](https://github.com/FalkorDB/FalkorDB/blob/ff108d7e21061025166a35d29be1a1cb5bac6d55/src/resultset/formatters/resultset_formatter.h#L14-L19), which as of RedisGraph v2.1.0 will always be `COLUMN_SCALAR`. This enum is retained for backwards compatibility, and may be ignored by the client unless RedisGraph versions older than v2.1.0 must be supported.
+[ColumnType](https://github.com/FalkorDB/FalkorDB/blob/ff108d7e21061025166a35d29be1a1cb5bac6d55/src/resultset/formatters/resultset_formatter.h#L14-L19), which as of v2.1.0 will always be `COLUMN_SCALAR`. This enum is retained for backwards compatibility, and may be ignored by the client unless versions older than v2.1.0 must be supported.
 
 [ValueType](https://github.com/FalkorDB/FalkorDB/blob/ff108d7e21061025166a35d29be1a1cb5bac6d55/src/resultset/formatters/resultset_formatter.h#L21-L28) indicates the data type (such as Node, integer, or string) of each returned value. Each value is emitted as a 2-array, with this enum in the first position and the actual value in the second. Each property on a graph entity also has a scalar as its value, so this construction is nested in each value of the properties array when a column contains a node or relationship.
 

--- a/path_algorithm.md
+++ b/path_algorithm.md
@@ -6,7 +6,7 @@ description: "Learn how to use algo.SPpaths and algo.SSpaths to find single-pair
 
 # Path algorithms
 
-RedisGraph 2.10 introduced two new path-finding algorithms, or more accurately, minimum-weight, optionally bounded-cost, and optionally bounded-length path-finding algorithms, `algo.SPpaths` and `algo.SSpaths`.
+In v2.10 introduced two new path-finding algorithms, or more accurately, minimum-weight, optionally bounded-cost, and optionally bounded-length path-finding algorithms, `algo.SPpaths` and `algo.SSpaths`.
 
 `algo.SPpaths` and `algo.SSpaths` can solve a wide range of real-world problems, where minimum-weight paths need to be found. `algo.SPpaths` finds paths between a given pair of nodes, while `algo.SSpaths` finds paths from a given source node. Weight can represent time, distance, price, or any other measurement. A bound can be set on another property (e.g., finding a minimum-time bounded-price way to reach from point A to point B). Both algorithms are performant and have low memory requirements.
 
@@ -44,9 +44,9 @@ GRAPH.QUERY g "CREATE (a:City{name:'A'}), (b:City{name:'B'}), (c:City{name:'C'})
 
 ![Road network](../images/graph_query_city.png)
 
-## Before RedisGraph 2.10
+## Before v2.10
 
-Before 2.10, you were able to solve these queries:
+Before v2.10, you were able to solve these queries:
 
 * Find the shortest path (by number of roads) from A to G
 * Find all the shortest paths (by number of roads) from A to G


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated various documentation sections for clarity and conciseness, including references to versioning for `GRAPH.CONSTRAINT CREATE`, configuration parameters, `ColumnType` enum, and path-finding algorithms.
	- Removed redundant mentions of "RedisGraph" in version references to simplify user understanding. 
	- Clarified default settings and behavior of configuration parameters related to query execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->