### PR TITLE
Add links to docs and add go lib

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -36,6 +36,7 @@ ISC
 Implementers
 IndexError
 JS
+JSDoc
 JSON
 KJDev
 Kepner
@@ -66,6 +67,7 @@ Ouaknine
 Parametrized
 Pieter
 Pinterest
+Pydoc
 RESULTSET
 RO
 RediSearch
@@ -125,6 +127,7 @@ exprList
 falkordb
 fulltext
 geospatial
+godoc
 hasLabels
 haversin
 https
@@ -134,6 +137,7 @@ indegree
 insertListElements
 ioredisgraph
 isEmpty
+javadocs
 jedis
 jfalkordb
 jinja

--- a/clients.md
+++ b/clients.md
@@ -7,12 +7,13 @@ description: >
 
 # Official Clients
 
-| Project                                                   | Language   | License    | Author                                      | Package                                  |
-| --------------------------------------------------------- | ---------- | ---------- | ------------------------------------------- | ---------------------------------------- |
-| [falkordb-py][falkordb-py-url]                            | Python     | MIT        | [FalkorDB][falkordb-url]                    | [pypi][falkordb-py-package]              |
-| [falkordb-ts][falkordb-ts-url]                            | Node.JS    | MIT        | [FalkorDB][falkordb-url]                    | [npm][falkordb-ts-package]               |
-| [jfalkordb][jfalkordb-url]                                | Java       | BSD        | [FalkorDB][falkordb-url]                    | [maven][jfalkordb-package]               |
-| [falkordb-rs][falkordb-rs-url]                            | Rust       | MIT        | [FalkorDB][falkordb-url]                    | [crates][falkordb-rs-package]             |
+| Project                            | Docs                 | Language   | License    | Author                                      | Package                                  |
+| -----------------------------------|--------------------- | ---------- | ---------- | ------------------------------------------- | ---------------------------------------- |
+| [falkordb-py][falkordb-py-url]    |  [Pydoc][falkordb-py-docs]                   | Python     | MIT        | [FalkorDB][falkordb-url]                    | [pypi][falkordb-py-package]              |
+| [falkordb-ts][falkordb-ts-url]    |  [JSDoc][falkordb-ts-docs] | Node.JS    | MIT        | [FalkorDB][falkordb-url]                    | [npm][falkordb-ts-package]               |
+| [jfalkordb][jfalkordb-url]        |  [javadocs][jfalkordb-docs] | Java       | BSD        | [FalkorDB][falkordb-url]                    | [maven][jfalkordb-package]               |
+| [falkordb-rs][falkordb-rs-url]    |  [docs.rs][falkordb-rs-docs]| Rust       | MIT        | [FalkorDB][falkordb-url]                    | [crates][falkordb-rs-package]             |
+| [falkordb-go][falkordb-go-url]    |  [godoc][falkordb-go-docs] | Go       | BSD        | [FalkorDB][falkordb-url]                    | [crates][falkordb-go-package]             |
 
 ## Additional Clients
 
@@ -39,15 +40,23 @@ description: >
 
 [falkordb-py-url]: https://github.com/falkordb/falkordb-py
 [falkordb-py-package]: https://pypi.python.org/pypi/falkordb
+[falkordb-py-docs]: https://falkordb-py.readthedocs.io/en/latest/
 
 [jfalkordb-url]: https://github.com/falkordb/jfalkordb
 [jfalkordb-package]: https://search.maven.org/artifact/com.falkordb/jfalkordb
+[jfalkordb-docs]: https://www.javadoc.io/doc/com.falkordb/jfalkordb
 
 [falkordb-ts-url]: https://github.com/falkordb/falkordb-ts
 [falkordb-ts-package]: https://www.npmjs.com/package/falkordb
+[falkordb-ts-docs]: https://www.npmjs.com/package/falkordb
 
 [falkordb-rs-url]: https://github.com/falkordb/falkordb-rs
 [falkordb-rs-package]: https://crates.io/crates/falkordb
+[falkordb-rs-docs]: https://docs.rs/falkordb/latest/falkordb
+
+[falkordb-go-url]: https://github.com/falkordb/falkordb-go
+[falkordb-go-package]: https://github.com/falkordb/falkordb-go
+[falkordb-go-docs]: https://pkg.go.dev/github.com/FalkorDB/falkordb-go
 
 [nredisstack-url]: https://github.com/redis/nredisstack
 [nredisstack-package]: https://www.nuget.org/packages/nredisstack/

--- a/cypher/cypher_support.md
+++ b/cypher/cypher_support.md
@@ -6,6 +6,8 @@ description: >
 parent: "Cypher Language"
 ---
 
+# Cypher coverage
+
 This document is based on the Cypher Query Language Reference (version 9), available at [OpenCypher Resources](https://www.opencypher.org/resources).
 
 ## Patterns

--- a/redisgraph-to-falkordb.md
+++ b/redisgraph-to-falkordb.md
@@ -4,7 +4,7 @@ nav_order: 11
 description: "Migrate from RedisGraph to FalkorDB."
 ---
 
-## FalkorDB is compatible with RedisGraph RDB files.
+# FalkorDB is compatible with RedisGraph RDB files.
 
 For the migration, execute the following steps:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Docs" column in the client libraries documentation, providing direct links to official documentation for easier access.
  - Added documentation links for the `falkordb-go` client along with other existing clients.

- **Documentation**
  - Improved clarity and accessibility of client library information in the `clients.md` file by enhancing table formatting and content.
  - Added a new section titled "Cypher coverage" in the cypher support documentation for better organization.
  - Minor formatting adjustment in the RedisGraph migration documentation to enhance visual prominence. 

- **Chores**
  - Added documentation-related terms (JSDoc, Pydoc, godoc, javadocs) to the wordlist for better reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->