### PR TITLE
add python to graph.query

### DIFF
--- a/commands/graph.query.md
+++ b/commands/graph.query.md
@@ -26,9 +26,16 @@ Query-level timeouts can be set as described in [the configuration section](/con
 
 example:
 
-```sh
+{% capture bash_0 %}
 GRAPH.QUERY us_government "MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
-```
+{% endcapture %}
+
+{% capture python_0 %}
+graph.query('MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p')
+{% endcapture %}
+
+{% include code_tabs.html id="tabs_0" bash=bash_0 python=python_0 %}
+
 
 #### Parametrized query structure:
 
@@ -36,9 +43,15 @@ GRAPH.QUERY us_government "MATCH (p:president)-[:born]->(:state {name:'Hawaii'})
 
 example:
 
-```sh
+{% capture bash_1 %}
 GRAPH.QUERY us_government "CYPHER state_name='Hawaii' MATCH (p:president)-[:born]->(:state {name:$state_name}) RETURN p"
-```
+{% endcapture %}
+
+{% capture python_1 %}
+graph.query("MATCH (p:president)-[:born]->(:state {name:$state_name}) RETURN p", {params: {state_name: 'Hawaii'}})
+{% endcapture %}
+
+{% include code_tabs.html id="tabs_1" bash=bash_1 python=python_1 %}
 
 ### Query language
 

--- a/commands/graph.query.md
+++ b/commands/graph.query.md
@@ -31,7 +31,7 @@ GRAPH.QUERY us_government "MATCH (p:president)-[:born]->(:state {name:'Hawaii'})
 {% endcapture %}
 
 {% capture python_0 %}
-graph.query('MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p')
+graph.query("MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p")
 {% endcapture %}
 
 {% include code_tabs.html id="tabs_0" bash=bash_0 python=python_0 %}

--- a/commands/graph.query.md
+++ b/commands/graph.query.md
@@ -48,7 +48,7 @@ GRAPH.QUERY us_government "CYPHER state_name='Hawaii' MATCH (p:president)-[:born
 {% endcapture %}
 
 {% capture python_1 %}
-graph.query("MATCH (p:president)-[:born]->(:state {name:$state_name}) RETURN p", {params: {state_name: 'Hawaii'}})
+graph.query("MATCH (p:president)-[:born]->(:state {name:$state_name}) RETURN p", {'state_name': 'Hawaii'})
 {% endcapture %}
 
 {% include code_tabs.html id="tabs_1" bash=bash_1 python=python_1 %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and structure of the `GRAPH.QUERY` command documentation.
	- Updated examples for Bash and Python using a new tabbed interface.
	- Improved presentation of parameterized query examples for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->