### PR TITLE
Add python example on ro_query

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -355,3 +355,4 @@ html
 body
 table
 Explainer
+ro

--- a/commands/graph.ro_query.md
+++ b/commands/graph.ro_query.md
@@ -14,8 +14,14 @@ Arguments: `Graph name, Query, Timeout [optional]`
 
 Returns: [Result set](/design/result_structure) for a read only query or an error if a write query was given.
 
-```sh
+{% capture shell_0 %}
 GRAPH.RO_QUERY us_government "MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
-```
+{% endcapture %}
+
+{% capture python_0 %}
+graph.ro_query("MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p")
+{% endcapture %}
+
+{% include code_tabs.html id="tabs_0" shell=shell_0 python=python_0 %}
 
 Query-level timeouts can be set as described in [the configuration section](/configuration#timeout).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the command guide with improved and organized code examples.
	- Replaced the previous shell example with a new Python code example presented in a tabbed format for easier comparison.
	- Enhanced clarity and presentation, while the core functionality remains unchanged.
- **Chores**
	- Added a line to the wordlist file for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->