### PR TITLE
add python copy example

### DIFF
--- a/commands/graph.copy.md
+++ b/commands/graph.copy.md
@@ -13,8 +13,9 @@ The `GRAPH.COPY` command creates a copy of a graph, while the copy is performed
 the `src` graph is fully accessible.
 
 Example:
-```
-127.0.0.1:6379> keys *
+
+{% capture shell_0 %}
+127.0.0.1:6379> GRAPH.LIST
 (empty array)
 127.0.0.1:6379> GRAPH.QUERY A "CREATE (:Account {number: 516637})"
 1) 1) "Labels added: 1"
@@ -24,7 +25,7 @@ Example:
    5) "Query internal execution time: 0.588084 milliseconds"
 127.0.0.1:6379> GRAPH.COPY A Z
 "OK"
-127.0.0.1:6379> keys *
+127.0.0.1:6379> GRAPH.LIST
 1) "Z"
 2) "telemetry{A}"
 3) "A"
@@ -33,4 +34,24 @@ Example:
 2) 1) 1) (integer) 516637
 3) 1) "Cached execution: 0"
    2) "Query internal execution time: 0.638375 milliseconds"
-```
+{% endcapture %}
+
+{% capture python_0 %}
+# Graphs list is empty
+graph_list = db.list()
+
+# Create Graph 'A'
+graph_a = db.select_graph('A')
+result = graph_a.query('CREATE (:Account {number: 516637})')
+
+# Copy Graph 'A' to 'Z'
+graph_z = graph_a.copy('A', 'Z')
+
+# Graphs list including 'A' and 'Z'
+graph_list = db.list()
+
+# Query Graph 'Z'
+result = graph_z.query('MATCH (a:Account) RETURN a.number')
+{% endcapture %}
+
+{% include code_tabs.html id="tabs_0" shell=shell_0 python=python_0 %}

--- a/commands/graph.copy.md
+++ b/commands/graph.copy.md
@@ -9,8 +9,7 @@ parent: "Commands"
 
 Usage: `GRAPH.COPY <src> <dest>`
 
-The `GRAPH.COPY` command creates a copy of a graph, while the copy is performed
-the `src` graph is fully accessible.
+The GRAPH.COPY command creates a copy of a graph while leaving the source graph fully accessible.
 
 Example:
 
@@ -45,7 +44,7 @@ graph_a = db.select_graph('A')
 result = graph_a.query('CREATE (:Account {number: 516637})')
 
 # Copy Graph 'A' to 'Z'
-graph_z = graph_a.copy('A', 'Z')
+graph_z = graph_a.copy('Z')
 
 # Graphs list including 'A' and 'Z'
 graph_list = db.list()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Revised description for the `GRAPH.COPY` command to clarify source graph accessibility during copy operations.
  - Expanded example section with a structured demonstration using shell commands and Python code, including the `GRAPH.LIST` command for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->