### PR TITLE
Add H1 to pages

### DIFF
--- a/integration/kafka-connect.md
+++ b/integration/kafka-connect.md
@@ -5,9 +5,9 @@ description: "Kafka Connect sink detailed doc"
 parent: "Integration"
 ---
 
+# Kafka Connect Sink
+
 ![FalkorDB x Kafka Connect Banner](https://github.com/user-attachments/assets/941bb532-8613-4135-b4c9-232a700da314)
-
-
 
 ## Get Started
 

--- a/integration/rest.md
+++ b/integration/rest.md
@@ -5,6 +5,8 @@ description: "Rest API detailed doc"
 parent: "Integration"
 ---
 
+# Rest API
+
 ## Table of Contents
 
 - [Login - GET /api/auth/providers](#login---get-apiauthproviders)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to ensure main headings appear as H1 headers at the top of the "Kafka Connect Sink" and "Rest API" integration guides for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->