### PR TITLE
Fix module path in k8s documentation

### DIFF
--- a/operations/k8s_support.md
+++ b/operations/k8s_support.md
@@ -37,11 +37,11 @@ image:
 
 master:
   extraFlags:
-  - "--loadmodule /FalkorDB/bin/src/falkordb.so"
+  - "--loadmodule /var/lib/falkordb/bin/falkordb.so"
 
 replica:
   extraFlags:
-  - "--loadmodule /FalkorDB/bin/src/falkordb.so"
+  - "--loadmodule /var/lib/falkordb/bin/falkordb.so"
 ```
 
 This file specify the FalkorDB image(you can choose different tags)


### PR DESCRIPTION
The module path in the helm values file is incorrect/ not working with the currentl `:latest` tag of FolkorDB.
I've corrected this.