### PR TITLE
change from header to headers

### DIFF
--- a/cypher/load_csv.md
+++ b/cypher/load_csv.md
@@ -70,7 +70,7 @@ MERGE (a:Actor {name: row[name], birth_year: toInteger(row[birthyear])})
 RETURN a.name, a.birth_year
 ```
 
-Note when a header row exists and `WITH HEADER` is specified the `row` variable
+Note when a header row exists and `WITH HEADERS` is specified the `row` variable
 is no longer an `array` but rather a `map`, accessing the individual elements
 is done via their column name.
 
@@ -96,7 +96,7 @@ We'll create a new graph connecting actors to the movies they've acted in
 Load actors:
 
 ```cypher
-LOAD CSV WITH HEADER FROM 'file://actors.csv'
+LOAD CSV WITH HEADERS FROM 'file://actors.csv'
 AS row
 MERGE (a:Actor {name:row['name']})
 ```
@@ -104,7 +104,7 @@ MERGE (a:Actor {name:row['name']})
 Load movies and create `ACTED_IN` relations:
 
 ```cypher
-LOAD CSV WITH HEADER FROM 'file://acted_in.csv'
+LOAD CSV WITH HEADERS FROM 'file://acted_in.csv'
 AS row
 
 MATCH (a:Actor {name: row['actor']})


### PR DESCRIPTION
Resolves: #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected all references to use `WITH HEADERS` instead of `WITH HEADER` in examples and explanations for the `LOAD CSV` Cypher clause.
  * Clarified how the `row` variable behaves when loading CSV files with headers.
  * Updated examples for improved accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->