### PR TITLE
docs(integration): add Jena integration page with Maven install and q…

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -455,3 +455,7 @@ DDTHH
 durations
 datetimes
 localdatetime
+Jena
+jena
+RDF
+SPARQL

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -433,7 +433,6 @@ myproject
 mut
 readOnlyQuery
 
-
 Dunder
 Mifflin
 scranton
@@ -445,4 +444,6 @@ Munger
 queryRelationships
 similarityFunction
 FIELDTERMINATOR
-
+backend
+md
+Opire

--- a/integration/index.md
+++ b/integration/index.md
@@ -11,9 +11,11 @@ The Integration section of the FalkorDB documentation provides all the necessary
 and integrating FalkorDB with your applications and workflows. 
 Learn how to leverage FalkorDB's flexible APIs and SDKs to build high-performance, low-latency graph applications.
 
+
 ## Topics in This Section
 
 - [REST API](./rest.md): Learn how to interact with FalkorDB using its REST API for seamless integration with your applications.
 - [Kafka Connect](./kafka-connect.md): Learn how to interact with FalkorDB using Kafka Connect sink to replicate data from third-party applications.
+- [Jena Integration](./jena.md): Learn how to use FalkorDB with Apache Jena via the jena-falkordb-adapter.
 
 

--- a/integration/jena.md
+++ b/integration/jena.md
@@ -40,27 +40,27 @@ import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 
 public class JenaFalkorExample {
-	public static void main(String[] args) {
-		// Create or obtain a Jena Model backed by FalkorDB.
-		// The exact factory method depends on the adapter; check the adapter README/Main.java for the
-		// connection options (hostname, port, credentials, etc.).
-		Model model = FalkorDBJenaFactory.createModel("http://localhost:7474");
+    public static void main(String[] args) {
+        // Create or obtain a Jena Model backed by FalkorDB.
+        // The exact factory method depends on the adapter; check the adapter README/Main.java for the
+        // connection options (hostname, port, credentials, etc.).
+        Model model = FalkorDBJenaFactory.createModel("http://localhost:7474");
 
-		// Example: add a triple
-		model.createResource("http://example.org/alice")
-			 .addProperty(model.createProperty("http://example.org/knows"),
-						  model.createResource("http://example.org/bob"));
+        // Example: add a triple
+        model.createResource("http://example.org/alice")
+             .addProperty(model.createProperty("http://example.org/knows"),
+                          model.createResource("http://example.org/bob"));
 
-		// Run a simple SPARQL SELECT
-		String sparql = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10";
-		try (QueryExecution qexec = QueryExecutionFactory.create(sparql, model)) {
-			ResultSet rs = qexec.execSelect();
-			ResultSetFormatter.out(System.out, rs);
-		}
+        // Run a simple SPARQL SELECT
+        String sparql = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10";
+        try (QueryExecution qexec = QueryExecutionFactory.create(sparql, model)) {
+            ResultSet rs = qexec.execSelect();
+            ResultSetFormatter.out(System.out, rs);
+        }
 
-		// Remember to close the model when finished
-		model.close();
-	}
+        // Remember to close the model when finished
+        model.close();
+    }
 }
 ```
 

--- a/integration/jena.md
+++ b/integration/jena.md
@@ -78,7 +78,3 @@ See the [Main.java](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/
 - [Adapter README](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/README.md)
 - [Getting Started](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/GETTING_STARTED.md)
 - [Sample Main.java](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/src/main/java/com/falkordb/jena/Main.java)
-
-## Opire
-
-This repository uses [Opire](https://github.com/apps/opirebot) for automated documentation and code review. Opire helps maintain high-quality documentation and code standards.

--- a/integration/jena.md
+++ b/integration/jena.md
@@ -1,0 +1,84 @@
+---
+title: "Jena Integration"
+description: "How to use FalkorDB with Apache Jena via the jena-falkordb-adapter."
+has_children: false
+nav_order: 6
+---
+
+# Jena Integration
+
+This page describes how to integrate FalkorDB with [Apache Jena](https://jena.apache.org/) using the [jena-falkordb-adapter](https://github.com/FalkorDB/jena-falkordb-adapter).
+
+## Overview
+
+The jena-falkordb-adapter allows applications built on Jena to use FalkorDB as a backend for RDF data storage and querying. This enables seamless graph data management and SPARQL query execution on FalkorDB.
+
+## Getting Started
+
+Follow the [GETTING_STARTED.md](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/GETTING_STARTED.md) guide for step-by-step instructions on setting up the adapter and connecting Jena to FalkorDB.
+
+### Install from Maven
+
+Add the FalkorDB Jena adapter dependency to your project's `pom.xml`. Replace the version with the latest release from the adapter repository.
+
+```xml
+<dependency>
+  <groupId>com.falkordb</groupId>
+  <artifactId>jena-falkordb-adapter</artifactId>
+  <version>0.2.0</version>
+</dependency>
+```
+
+If the adapter is published to a non-standard Maven repository, add the repository block shown in the adapter's README. Otherwise the dependency should resolve from Maven Central (if published there).
+
+### Quick Getting Started (Java)
+
+The snippet below shows a minimal Jena program that registers the FalkorDB adapter and runs a simple SPARQL query. This is intentionally small — see the adapter's `GETTING_STARTED.md` and `Main.java` for a complete example with configuration and connection options.
+
+```java
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.Model;
+
+public class JenaFalkorExample {
+	public static void main(String[] args) {
+		// Create or obtain a Jena Model backed by FalkorDB.
+		// The exact factory method depends on the adapter; check the adapter README/Main.java for the
+		// connection options (hostname, port, credentials, etc.).
+		Model model = FalkorDBJenaFactory.createModel("http://localhost:7474");
+
+		// Example: add a triple
+		model.createResource("http://example.org/alice")
+			 .addProperty(model.createProperty("http://example.org/knows"),
+						  model.createResource("http://example.org/bob"));
+
+		// Run a simple SPARQL SELECT
+		String sparql = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10";
+		try (QueryExecution qexec = QueryExecutionFactory.create(sparql, model)) {
+			ResultSet rs = qexec.execSelect();
+			ResultSetFormatter.out(System.out, rs);
+		}
+
+		// Remember to close the model when finished
+		model.close();
+	}
+}
+```
+
+Notes:
+- Replace `FalkorDBJenaFactory.createModel(...)` with the actual adapter factory call used in the adapter (see `Main.java`).
+- Use the adapter's configuration options (connection URL, authentication) when creating the model.
+
+
+## Usage Example
+
+See the [Main.java](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/src/main/java/com/falkordb/jena/Main.java) for a sample Java application demonstrating how to use the adapter.
+
+## Reference
+
+- [Adapter README](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/README.md)
+- [Getting Started](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/GETTING_STARTED.md)
+- [Sample Main.java](https://github.com/FalkorDB/jena-falkordb-adapter/blob/main/src/main/java/com/falkordb/jena/Main.java)
+
+## Opire
+
+This repository uses [Opire](https://github.com/apps/opirebot) for automated documentation and code review. Opire helps maintain high-quality documentation and code standards.


### PR DESCRIPTION
fix #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Jena Integration guide covering using FalkorDB with Apache Jena via the adapter, setup, dependency snippet, configuration, adapter usage, a Java quick-start example (model creation, RDF triple handling, SPARQL), and reference/usage notes.
  * Updated integrations index to link to the new guide.
* **Chores**
  * Updated internal wordlist entries (three removed, three added).
* No changes to product behavior or APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->