### PR TITLE
Update kuzu-to-falkordb.md repo location change

### DIFF
--- a/migration/kuzu-to-falkordb.md
+++ b/migration/kuzu-to-falkordb.md
@@ -44,7 +44,7 @@ pip3 install kuzu
 2. Download the migration script:
 
 ```bash
-git clone https://github.com/FalkorDB-POCs/Kuzu-to-FalkorDB.git
+git clone https://github.com/FalkorDB/Kuzu-to-FalkorDB.git
 cd Kuzu-to-FalkorDB
 ```
 


### PR DESCRIPTION
from FalkorDB-POCs to FalkorDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to reference the official repository for the Kuzu-to-FalkorDB tool, replacing an outdated URL.
  * Clarified the cloning step while keeping the rest of the installation instructions unchanged.
  * Improves reliability of setup by preventing broken link issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->