### PR TITLE
Fix FLEX UDF docs navigation

### DIFF
--- a/udfs/flex/bitwise/and.md
+++ b/udfs/flex/bitwise/and.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: bitwise.and
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # bitwise.and
 
 ## Description

--- a/udfs/flex/bitwise/not.md
+++ b/udfs/flex/bitwise/not.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: bitwise.not
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # bitwise.not
 
 ## Description

--- a/udfs/flex/bitwise/or.md
+++ b/udfs/flex/bitwise/or.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: bitwise.or
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # bitwise.or
 
 ## Description

--- a/udfs/flex/bitwise/shiftLeft.md
+++ b/udfs/flex/bitwise/shiftLeft.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: bitwise.shiftLeft
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # bitwise.shiftLeft
 
 ## Description

--- a/udfs/flex/bitwise/shiftRight.md
+++ b/udfs/flex/bitwise/shiftRight.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: bitwise.shiftRight
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # bitwise.shiftRight
 
 ## Description

--- a/udfs/flex/bitwise/xor.md
+++ b/udfs/flex/bitwise/xor.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: bitwise.xor
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # bitwise.xor
 
 ## Description

--- a/udfs/flex/collections/frequencies.md
+++ b/udfs/flex/collections/frequencies.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: coll.frequencies
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # coll.frequencies
 
 ## Description

--- a/udfs/flex/collections/intersection.md
+++ b/udfs/flex/collections/intersection.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: coll.intersection
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # coll.intersection
 
 ## Description

--- a/udfs/flex/collections/shuffle.md
+++ b/udfs/flex/collections/shuffle.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: coll.shuffle
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # coll.shuffle
 
 ## Description

--- a/udfs/flex/collections/union.md
+++ b/udfs/flex/collections/union.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: coll.union
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # coll.union
 
 ## Description

--- a/udfs/flex/collections/zip.md
+++ b/udfs/flex/collections/zip.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: coll.zip
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # coll.zip
 
 ## Description

--- a/udfs/flex/date/format.md
+++ b/udfs/flex/date/format.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: date.format
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # date.format
 
 ## Description

--- a/udfs/flex/date/parse.md
+++ b/udfs/flex/date/parse.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: date.parse
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # date.parse
 
 ## Description

--- a/udfs/flex/date/toTimeZone.md
+++ b/udfs/flex/date/toTimeZone.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: date.toTimeZone
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # date.toTimeZone
 
 ## Description

--- a/udfs/flex/date/truncate.md
+++ b/udfs/flex/date/truncate.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: date.truncate
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # date.truncate
 
 ## Description

--- a/udfs/flex/index.md
+++ b/udfs/flex/index.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: FLEX Function Reference
+parent: UDFs - User Defined Functions
+has_children: true
+---
+
 # FLEX Function Reference
 
 FLEX is FalkorDB's open source community UDF package, available at [github.com/FalkorDB/flex](https://github.com/FalkorDB/flex).  

--- a/udfs/flex/json/fromJsonList.md
+++ b/udfs/flex/json/fromJsonList.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: json.fromJsonList
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # json.fromJsonList
 
 ## Description

--- a/udfs/flex/json/fromJsonMap.md
+++ b/udfs/flex/json/fromJsonMap.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: json.fromJsonMap
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # json.fromJsonMap
 
 ## Description

--- a/udfs/flex/json/toJson.md
+++ b/udfs/flex/json/toJson.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: json.toJson
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # json.toJson
 
 ## Description

--- a/udfs/flex/map/fromPairs.md
+++ b/udfs/flex/map/fromPairs.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: map.fromPairs
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # map.fromPairs
 
 ## Description

--- a/udfs/flex/map/merge.md
+++ b/udfs/flex/map/merge.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: map.merge
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # map.merge
 
 ## Description

--- a/udfs/flex/map/removeKey.md
+++ b/udfs/flex/map/removeKey.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: map.removeKey
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # map.removeKey
 
 ## Description

--- a/udfs/flex/map/removeKeys.md
+++ b/udfs/flex/map/removeKeys.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: map.removeKeys
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # map.removeKeys
 
 ## Description

--- a/udfs/flex/map/submap.md
+++ b/udfs/flex/map/submap.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: map.submap
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # map.submap
 
 ## Description

--- a/udfs/flex/similarity/jaccard.md
+++ b/udfs/flex/similarity/jaccard.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: sim.jaccard
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # sim.jaccard
 
 ## Description

--- a/udfs/flex/text/camelCase.md
+++ b/udfs/flex/text/camelCase.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.camelCase
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.camelCase
 
 ## Description

--- a/udfs/flex/text/capitalize.md
+++ b/udfs/flex/text/capitalize.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.capitalize
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.capitalize
 
 ## Description

--- a/udfs/flex/text/decapitalize.md
+++ b/udfs/flex/text/decapitalize.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.decapitalize
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.decapitalize
 
 ## Description

--- a/udfs/flex/text/format.md
+++ b/udfs/flex/text/format.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.format
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.format
 
 ## Description

--- a/udfs/flex/text/indexOf.md
+++ b/udfs/flex/text/indexOf.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.indexOf
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.indexOf
 
 ## Description

--- a/udfs/flex/text/indexesOf.md
+++ b/udfs/flex/text/indexesOf.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.indexesOf
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.indexesOf
 
 ## Description

--- a/udfs/flex/text/jaroWinkler.md
+++ b/udfs/flex/text/jaroWinkler.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.jaroWinkler
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.jaroWinkler
 
 ## Description

--- a/udfs/flex/text/join.md
+++ b/udfs/flex/text/join.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.join
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.join
 
 ## Description

--- a/udfs/flex/text/levenshtein.md
+++ b/udfs/flex/text/levenshtein.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.levenshtein
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.levenshtein
 
 ## Description

--- a/udfs/flex/text/lpad.md
+++ b/udfs/flex/text/lpad.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.lpad
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.lpad
 
 ## Description

--- a/udfs/flex/text/regexGroups.md
+++ b/udfs/flex/text/regexGroups.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.regexGroups
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.regexGroups
 
 ## Description

--- a/udfs/flex/text/repeat.md
+++ b/udfs/flex/text/repeat.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.repeat
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.repeat
 
 ## Description

--- a/udfs/flex/text/replace.md
+++ b/udfs/flex/text/replace.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.replace
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.replace
 
 ## Description

--- a/udfs/flex/text/rpad.md
+++ b/udfs/flex/text/rpad.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.rpad
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.rpad
 
 ## Description

--- a/udfs/flex/text/snakeCase.md
+++ b/udfs/flex/text/snakeCase.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.snakeCase
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.snakeCase
 
 ## Description

--- a/udfs/flex/text/swapCase.md
+++ b/udfs/flex/text/swapCase.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.swapCase
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.swapCase
 
 ## Description

--- a/udfs/flex/text/upperCamelCase.md
+++ b/udfs/flex/text/upperCamelCase.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: text.upperCamelCase
+parent: FLEX Function Reference
+grand_parent: UDFs - User Defined Functions
+---
+
 # text.upperCamelCase
 
 ## Description

--- a/udfs/index.md
+++ b/udfs/index.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: UDFs - User Defined Functions
+has_children: true
+---
+
 # UDFs - User Defined Functions
 
 Every databases comes with a set of built-in functions, for example among FalkorDB functions you'll find:


### PR DESCRIPTION
Group all FLEX function pages under the FLEX Function Reference page in the Just the Docs navigation.

Co-Authored-By: Warp <agent@warp.dev>
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a documentation navigation issue for FLEX User Defined Functions (UDFs) by adding necessary metadata to the Markdown files. This ensures proper hierarchical display and navigation within the documentation.

#### Key Changes
- Added YAML front matter to all FLEX UDF documentation Markdown files.
- Included `layout`, `title`, `parent`, and `grand_parent` fields in the front matter to define the documentation structure.
- Updated `udfs/flex/index.md` and `udfs/index.md` to include `has_children: true` for correct parent-child relationships in the navigation.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 300 (100.0%)  |
| Total Changes | 300         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced FLEX UDF reference documentation with improved organization and metadata structure for better navigation.
  * Expanded comprehensive documentation for bitwise operations, collections, date/time, JSON, map operations, similarity, and text manipulation functions, including complete syntax, parameters, examples, and usage notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->