### PR TITLE
Fix FLEX function parameter tables

### DIFF
--- a/udfs/flex/bitwise/and.md
+++ b/udfs/flex/bitwise/and.md
@@ -16,6 +16,7 @@ flex.bitwise.and(a, b)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `a` | number (integer) | Yes | First operand |

--- a/udfs/flex/bitwise/not.md
+++ b/udfs/flex/bitwise/not.md
@@ -16,6 +16,7 @@ flex.bitwise.not(a)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `a` | number (integer) | Yes | The operand to invert |

--- a/udfs/flex/bitwise/or.md
+++ b/udfs/flex/bitwise/or.md
@@ -16,6 +16,7 @@ flex.bitwise.or(a, b)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `a` | number (integer) | Yes | First operand |

--- a/udfs/flex/bitwise/shiftLeft.md
+++ b/udfs/flex/bitwise/shiftLeft.md
@@ -16,6 +16,7 @@ flex.bitwise.shiftLeft(a, positions)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `a` | number (integer) | Yes | The value to shift |

--- a/udfs/flex/bitwise/shiftRight.md
+++ b/udfs/flex/bitwise/shiftRight.md
@@ -16,6 +16,7 @@ flex.bitwise.shiftRight(a, positions)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `a` | number (integer) | Yes | The value to shift |

--- a/udfs/flex/bitwise/xor.md
+++ b/udfs/flex/bitwise/xor.md
@@ -16,6 +16,7 @@ flex.bitwise.xor(a, b)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `a` | number (integer) | Yes | First operand |

--- a/udfs/flex/collections/frequencies.md
+++ b/udfs/flex/collections/frequencies.md
@@ -16,6 +16,7 @@ flex.coll.frequencies(list)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `list` | list | Yes | The list to analyze |

--- a/udfs/flex/collections/intersection.md
+++ b/udfs/flex/collections/intersection.md
@@ -16,6 +16,7 @@ flex.coll.intersection(list1, list2)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `list1` | list | Yes | The first list |

--- a/udfs/flex/collections/shuffle.md
+++ b/udfs/flex/collections/shuffle.md
@@ -16,6 +16,7 @@ flex.coll.shuffle(list)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `list` | list | Yes | The list to shuffle |

--- a/udfs/flex/collections/union.md
+++ b/udfs/flex/collections/union.md
@@ -16,6 +16,7 @@ flex.coll.union(list1, list2)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `list1` | list | Yes | The first list |

--- a/udfs/flex/collections/zip.md
+++ b/udfs/flex/collections/zip.md
@@ -16,6 +16,7 @@ flex.coll.zip(list1, list2)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `list1` | list | Yes | The first list |

--- a/udfs/flex/date/format.md
+++ b/udfs/flex/date/format.md
@@ -16,6 +16,7 @@ flex.date.format(datetime, pattern, timezone)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `datetime` | Date/number/string | Yes | The date/time value to format |

--- a/udfs/flex/date/parse.md
+++ b/udfs/flex/date/parse.md
@@ -16,6 +16,7 @@ flex.date.parse(dateString, pattern, timezone)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `dateString` | string | Yes | The date/time string to parse |

--- a/udfs/flex/date/toTimeZone.md
+++ b/udfs/flex/date/toTimeZone.md
@@ -16,6 +16,7 @@ flex.date.toTimeZone(datetime, timezone)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `datetime` | Date/number/string | Yes | The date/time value to convert |

--- a/udfs/flex/date/truncate.md
+++ b/udfs/flex/date/truncate.md
@@ -16,6 +16,7 @@ flex.date.truncate(datetime, unit)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `datetime` | Date/number/string | Yes | The date/time value to truncate |

--- a/udfs/flex/json/fromJsonList.md
+++ b/udfs/flex/json/fromJsonList.md
@@ -16,6 +16,7 @@ flex.json.fromJsonList(jsonString)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `jsonString` | string | Yes | A JSON string representing an array |

--- a/udfs/flex/json/fromJsonMap.md
+++ b/udfs/flex/json/fromJsonMap.md
@@ -16,6 +16,7 @@ flex.json.fromJsonMap(jsonString)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `jsonString` | string | Yes | A JSON string representing an object |

--- a/udfs/flex/json/toJson.md
+++ b/udfs/flex/json/toJson.md
@@ -16,6 +16,7 @@ flex.json.toJson(value)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `value` | any | Yes | The value to serialize to JSON |

--- a/udfs/flex/map/fromPairs.md
+++ b/udfs/flex/map/fromPairs.md
@@ -16,6 +16,7 @@ flex.map.fromPairs(pairs)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `pairs` | list | Yes | A list of two-element arrays, each containing `[key, value]` |

--- a/udfs/flex/map/merge.md
+++ b/udfs/flex/map/merge.md
@@ -16,6 +16,7 @@ flex.map.merge(map1, map2, ...)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `map1` | map | No | First map to merge |

--- a/udfs/flex/map/removeKey.md
+++ b/udfs/flex/map/removeKey.md
@@ -16,6 +16,7 @@ flex.map.removeKey(map, key)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `map` | map | Yes | The map to remove the key from |

--- a/udfs/flex/map/removeKeys.md
+++ b/udfs/flex/map/removeKeys.md
@@ -16,6 +16,7 @@ flex.map.removeKeys(map, keys)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `map` | map | Yes | The map to remove keys from |

--- a/udfs/flex/map/submap.md
+++ b/udfs/flex/map/submap.md
@@ -16,6 +16,7 @@ flex.map.submap(map, keys)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `map` | map | Yes | The source map to extract keys from |

--- a/udfs/flex/similarity/jaccard.md
+++ b/udfs/flex/similarity/jaccard.md
@@ -16,6 +16,7 @@ flex.sim.jaccard(list1, list2)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `list1` | list | Yes | The first list to compare |

--- a/udfs/flex/text/camelCase.md
+++ b/udfs/flex/text/camelCase.md
@@ -16,6 +16,7 @@ flex.text.camelCase(string)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to convert to camelCase |

--- a/udfs/flex/text/capitalize.md
+++ b/udfs/flex/text/capitalize.md
@@ -16,6 +16,7 @@ flex.text.capitalize(string)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to capitalize |

--- a/udfs/flex/text/decapitalize.md
+++ b/udfs/flex/text/decapitalize.md
@@ -16,6 +16,7 @@ flex.text.decapitalize(string)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to decapitalize |

--- a/udfs/flex/text/format.md
+++ b/udfs/flex/text/format.md
@@ -16,6 +16,7 @@ flex.text.format(template, parameters)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `template` | string | Yes | The format string containing `{0}`, `{1}`, etc. placeholders |

--- a/udfs/flex/text/indexOf.md
+++ b/udfs/flex/text/indexOf.md
@@ -16,6 +16,7 @@ flex.text.indexOf(string, substring, offset, to)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to search in |

--- a/udfs/flex/text/indexesOf.md
+++ b/udfs/flex/text/indexesOf.md
@@ -16,6 +16,7 @@ flex.text.indexesOf(string, substring, from, to)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to search in |

--- a/udfs/flex/text/jaroWinkler.md
+++ b/udfs/flex/text/jaroWinkler.md
@@ -16,6 +16,7 @@ flex.text.jaroWinkler(string1, string2)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string1` | string | Yes | The first string to compare |

--- a/udfs/flex/text/join.md
+++ b/udfs/flex/text/join.md
@@ -16,6 +16,7 @@ flex.text.join(array, delimiter)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `array` | list | Yes | The array of strings to join |

--- a/udfs/flex/text/levenshtein.md
+++ b/udfs/flex/text/levenshtein.md
@@ -16,6 +16,7 @@ flex.text.levenshtein(string1, string2)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string1` | string | Yes | The first string to compare |

--- a/udfs/flex/text/lpad.md
+++ b/udfs/flex/text/lpad.md
@@ -16,6 +16,7 @@ flex.text.lpad(string, length, padChar)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string/number | Yes | The string to pad (will be converted to string if number) |

--- a/udfs/flex/text/regexGroups.md
+++ b/udfs/flex/text/regexGroups.md
@@ -16,6 +16,7 @@ flex.text.regexGroups(string, regex)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to search in |

--- a/udfs/flex/text/repeat.md
+++ b/udfs/flex/text/repeat.md
@@ -16,6 +16,7 @@ flex.text.repeat(string, count)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to repeat |

--- a/udfs/flex/text/replace.md
+++ b/udfs/flex/text/replace.md
@@ -16,6 +16,7 @@ flex.text.replace(string, regex, replacement)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to perform replacements on |

--- a/udfs/flex/text/rpad.md
+++ b/udfs/flex/text/rpad.md
@@ -16,6 +16,7 @@ flex.text.rpad(string, length, padChar)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string/number | Yes | The string to pad (will be converted to string if number) |

--- a/udfs/flex/text/snakeCase.md
+++ b/udfs/flex/text/snakeCase.md
@@ -16,6 +16,7 @@ flex.text.snakeCase(string)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to convert to snake_case |

--- a/udfs/flex/text/swapCase.md
+++ b/udfs/flex/text/swapCase.md
@@ -16,6 +16,7 @@ flex.text.swapCase(string)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to swap case |

--- a/udfs/flex/text/upperCamelCase.md
+++ b/udfs/flex/text/upperCamelCase.md
@@ -16,6 +16,7 @@ flex.text.upperCamelCase(string)
 ```
 
 ## Parameters
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `string` | string | Yes | The string to convert to UpperCamelCase |


### PR DESCRIPTION
Ensure there is a blank line between each '## Parameters' heading and the following Markdown table so parameter definitions render correctly in FLEX function docs.

Co-Authored-By: Warp <agent@warp.dev>
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a minor formatting issue in the documentation for various FLEX functions by adding a blank line before the "Parameters" section.

#### Key Changes
- Added a blank line before the `## Parameters` heading in 41 documentation files for FLEX User-Defined Functions (UDFs). This improves the visual separation and readability of the parameter tables.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 41 (100%)     |
| Total Changes | 41         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting consistency across function documentation with enhanced parameter table structure
  * Updated parameter documentation for multiple functions to accurately reflect their signatures and inputs
  * Added clarification of previously undocumented parameters in text manipulation, date, collection, and map functions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->