### PR TITLE
Add ENCRYPTION_KEY to REST API setup docs

### DIFF
--- a/integration/rest.md
+++ b/integration/rest.md
@@ -23,12 +23,24 @@ To start using the FalkorDB Browser REST API, follow these simple steps:
 
 #### 1. Environment Setup
 
-Before you can authenticate, configure these required environment variables:
+Before you can authenticate, configure the required environment variables:
 
-- **NEXTAUTH_SECRET** - Secret for JWT signing (generate with: `openssl rand -base64 32`)
-- **ENCRYPTION_KEY** - Key for encrypting stored credentials (generate with: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`)
+**Step 1:** Copy the template
+```bash
+cp .env.local.template .env.local
+```
 
-Without these environment variables, the authentication endpoints will fail with server configuration errors.
+**Step 2:** Generate and add ENCRYPTION_KEY
+```bash
+openssl rand -hex 32
+```
+
+Add the generated key to your `.env.local` file:
+```
+ENCRYPTION_KEY=<generated_key>
+```
+
+Without the ENCRYPTION_KEY, the authentication endpoints will fail with server configuration errors.
 
 #### 2. Authentication
 First, you need to authenticate to get a JWT token:


### PR DESCRIPTION
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Environment Setup section to REST API docs with guidance on generating and configuring ENCRYPTION_KEY.
  * Clarified authentication setup and updated error messaging to reflect missing NEXTAUTH_SECRET or ENCRYPTION_KEY.
  * Expanded example error responses to include server-configuration (500) cases.
  * Reordered and reformatted sections for clearer flow and improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the REST API setup documentation to include instructions for configuring the `ENCRYPTION_KEY`, which is now a prerequisite for authentication endpoints to function correctly.

#### Key Changes
- Introduced a new "Environment Setup" section with steps to generate and add the `ENCRYPTION_KEY` to the `.env.local` file.
- Clarified that authentication endpoints will fail without the `ENCRYPTION_KEY`.
- Updated the numbering of subsequent setup steps (Authentication, Check Connection Status, etc.).
- Modified the 500 server configuration error message to explicitly mention `ENCRYPTION_KEY` as a potential missing variable.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 27 (81.8%) lines |
| Rework      | 6 (18.2%) lines |
| Total Changes | 33 (100.0%) lines | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>