### PR TITLE
Fix markdown formatting in Browser documentation

### DIFF
--- a/browser/readme-browser.md
+++ b/browser/readme-browser.md
@@ -15,76 +15,107 @@ FalkorDB's Browser provides a web UI for exploring, querying, and managing Falko
 ## Main Features
 
 ### Graph exploration (Graph page)
-| Feature                           | Description                                                                                                                                                                                         |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Interactive graph canvas          | Visualizes query results containing nodes and edges as an interactive graph. Supports pan, zoom, and interaction with nodes and relationships. Toggles visibility by labels and relationship types. |
-| Element search (in-canvas search) | Search nodes and edges by node properties (string prefix match), IDs, relationship type, and labels. Jump to, zoom to, and select the match.                                                        |
-| Data and inspection panel         | Selecting an element opens a side panel for inspecting its properties. This panel supports editing workflows (see "Data manipulation").                                                             |
-| Entity Creation Tools             | Add a node, an edge, or both to the current graph from the canvas view.                                                                                                                             |
+- **Interactive graph canvas**
+  - Visualizes query results containing nodes and edges as an interactive graph
+  - Supports pan, zoom, and interaction with nodes and relationships
+  - Toggles visibility by labels and relationship types
+- **Element search (in-canvas search)**
+  - Search nodes and edges by node properties (string prefix match), IDs, relationship type, and labels
+  - Jump to, zoom to, and select the match
+- **Data and inspection panel**
+  - Selecting an element opens a side panel for inspecting its properties
+  - This panel supports editing workflows (see "Data manipulation")
+- **Entity Creation Tools**
+  - Add a node, an edge, or both to the current graph from the canvas view
 
 ### Querying
-| Feature                      | Description                                                                                                                                                                                                                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Cypher query editor (Monaco) | The editor-style experience for writing Cypher includes keyboard shortcuts: Run (Enter and Cmd/Ctrl + Enter in the query-history editor) and Insert newline (Shift + Enter). The editor includes Cypher keyword and function completion based on the Browser's built-in lists. |
-| Results views                | Graph view for node and edge results. Table view for tabular results.                                                                                                                                                                                                          |
-| Query metadata               | The Metadata tab shows query metadata text, explain plan (rendered as a nested tree), and profile output (rendered as a nested tree).                                                                                                                                          |
+- **Cypher query editor (Monaco)**
+  - Editor-style experience for writing Cypher
+  - Keyboard shortcuts: Run (Enter and Cmd/Ctrl + Enter in the query-history editor) and Insert newline (Shift + Enter)
+  - Includes Cypher keyword and function completion based on the Browser's built-in lists
+- **Results views**
+  - Graph view for node and edge results
+  - Table view for tabular results
+- **Query metadata**
+  - The Metadata tab shows query metadata text, explain plan (rendered as a nested tree), and profile output (rendered as a nested tree)
 
 ### Query history
-| Feature                  | Description                                                                                                                                    |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Persistent query history | Stores in browser localStorage.                                                                                                                |
-| History browser dialog   | Allows you to search and filter previous queries, filter by graph name, and delete single queries, multi-select delete, or delete all queries. |
-| Per-query metadata       | Review metadata, explain, and profile for past queries.                                                                                        |
+- **Persistent query history** stored in browser localStorage
+- **History browser dialog**
+  - Search and filter previous queries
+  - Filter by graph name
+  - Delete single queries, multi-select delete, or delete all queries
+- **Per-query metadata**
+  - Review metadata, explain, and profile for past queries
 <img width="1419" height="825" alt="query-history-eye-candy" src="https://github.com/user-attachments/assets/be000961-f456-4b04-adf0-96f754b7447a" />
 
 
 ### Data manipulation (nodes/relationships)
-| Feature                      | Description                                                                                                            |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Create and delete operations | Create node and create relationship flows from the Graph UI. Delete elements (node or relationship) from the Graph UI. |
-| Edit labels                  | Edit labels through API routes (the UI provides label management components).                                          |
+- **Create and delete operations**
+  - Create node and create relationship flows from the Graph UI
+  - Delete elements (node or relationship) from the Graph UI
+- **Edit labels**
+  - Edit labels through API routes (the UI provides label management components)
 
 ### Graph management
-| Feature          | Description                                                                                              |
-| ---------------- | -------------------------------------------------------------------------------------------------------- |
-| Create graphs    | Create graphs from the UI.                                                                               |
-| Delete graphs    | Delete graphs (supports deleting multiple selected graphs).                                              |
-| Duplicate graphs | Create a copy of an existing graph (including data).                                                     |
-| Export graphs    | Download a .dump file via the Browser (/api/graph/:graph/export).                                        |
-| Upload data      | Upload data through the "Upload Data" dialog, which supports drag-and-drop file selection (Dropzone UI). |
+- **Create graphs** from the UI
+- **Delete graphs** (supports deleting multiple selected graphs)
+- **Duplicate graphs**
+  - Create a copy of an existing graph (including data)
+- **Export graphs**
+  - Download a `.dump` file via the Browser (`/api/graph/:graph/export`)
+- **Upload data**
+  - Upload data through the "Upload Data" dialog, which supports drag-and-drop file selection (Dropzone UI)
 
 ### Graph Info panel
-| Feature                | Description                                                                                                                                                        |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Memory Usage tracking  | Exposes current memory utilization of the graph in MB.                                                                                                             |
-| Node Label tracking    | Displays all node labels in the graph and controls style visualization for labels. Click on a node label to trigger a query that visualizes nodes from this label. |
-| Edge Type tracking     | Displays all edge types in the graph. Click on an edge type to trigger a graph query showing only nodes connected through this edge type.                          |
-| Property Keys tracking | Displays all property keys in the graph. Click on a key to issue a query that shows nodes and edges where the property exists (not NULL).                          |
+- **Memory Usage tracking**
+  - Exposes current memory utilization of the graph in MB
+- **Node Label tracking**
+  - Displays all node labels in the graph and controls style visualization for labels
+  - Click on a node label to trigger a query that visualizes nodes from this label
+- **Edge Type tracking**
+  - Displays all edge types in the graph
+  - Click on an edge type to trigger a graph query showing only nodes connected through this edge type
+- **Property Keys tracking**
+  - Displays all property keys in the graph
+  - Click on a key to issue a query that shows nodes and edges where the property exists (not NULL)
 <img width="1419" height="825" alt="falkordb-browser-eye-candy" src="https://github.com/user-attachments/assets/74375cd1-c704-40a9-9339-f1f885135a75" />
 
 ---
 
 ### API Documentation
-| Feature             | Description                                                                                                                                                           |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Built-in Swagger UI | Available at /docs. Loads the Browser's OpenAPI spec from /api/swagger. "Try it out" enabled. Adds an X-JWT-Only: true header when calling endpoints from Swagger UI. |
+- **Built-in Swagger UI** at `/docs`
+  - Loads the Browser's OpenAPI spec from `/api/swagger`
+  - "Try it out" enabled
+  - Adds an `X-JWT-Only: true` header when calling endpoints from Swagger UI
 
 <img width="1419" height="825" alt="browser-api-doc-eye-candy" src="https://github.com/user-attachments/assets/35b0ca72-83f7-4f16-927c-413bf5f65593" />
 
 
 ### Authentication & access control
-| Feature                    | Description                                                                                                                   |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Authentication             | Uses NextAuth (credentials-backed) for authentication.                                                                        |
-| Role-aware UI capabilities | Read-Only users cannot create graphs. Admin users can access database configuration and user-management sections in settings. |
+- **Authentication**
+  - Uses NextAuth (credentials-backed) for authentication
+- **Role-aware UI capabilities**
+  - Read-Only users cannot create graphs
+  - Admin users can access database configuration and user-management sections in settings
 
 ### Settings
-| Section                   | Description                                                                                                                                                                                                                                                                          |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Browser settings          | Query execution defaults and limits: timeout, result limit, run default query on load. User experience: content persistence (auto-save and restore), display-text priority (controls which node property appears as the node caption). Graph info refresh interval. Tutorial replay. |
-| DB configurations (Admin) | View and update server configuration values. Some runtime configurations remain read-only.                                                                                                                                                                                           |
-| Users (Admin)             | List users and adjust roles. Add and delete users.                                                                                                                                                                                                                                   |
-| Personal Access Tokens    | Generate tokens (with optional expiration). Tokens appear once at creation (copy-to-clipboard UX). Revoke existing tokens.                                                                                                                                                           |
+The `/settings` area includes multiple sections:
+- **Browser settings**
+  - Query execution defaults and limits: timeout, result limit, run default query on load
+  - User experience: content persistence (auto-save and restore), display-text priority (controls which node property appears as the node caption)
+  - Graph info refresh interval
+  - Tutorial replay
+- **DB configurations (Admin)**
+  - View and update server configuration values
+  - Some runtime configurations remain read-only
+- **Users (Admin)**
+  - List users and adjust roles
+  - Add and delete users
+- **Personal Access Tokens**
+  - Generate tokens (with optional expiration)
+  - Tokens appear once at creation (copy-to-clipboard UX)
+  - Revoke existing tokens
 <!--
 ### Optional “Chat” (English → Cypher)
 If enabled, the Browser includes a **Chat panel** that streams responses from a text-to-cypher service.
@@ -97,34 +128,26 @@ If enabled, the Browser includes a **Chat panel** that streams responses from a 
 
 ## Common Workflows
 ### Running and visualizing queries
-| Step | Action                                                                                 |
-| ---- | -------------------------------------------------------------------------------------- |
-| 1    | Go to Graphs and select a graph.                                                       |
-| 2    | Write a Cypher query in the editor and run it.                                         |
-| 3    | Inspect results in the Graph tab (interactive canvas) or Table tab (rows and columns). |
-| 4    | Use Labels and Relationships toggles to focus the canvas.                              |
+1. Go to **Graphs** and select a graph
+2. Write a Cypher query in the editor and run it
+3. Inspect results in the **Graph** tab (interactive canvas) or **Table** tab (rows and columns)
+4. Use **Labels** and **Relationships** toggles to focus the canvas
 
 [NEED GIF HERE]
 
 ### Inspecting and editing elements
-| Step | Action                                                                                 |
-| ---- | -------------------------------------------------------------------------------------- |
-| 1    | Click a node or edge in the canvas.                                                    |
-| 2    | Use the Data panel to inspect properties and apply create or delete actions as needed. |
+1. Click a node or edge in the canvas
+2. Use the **Data panel** to inspect properties and apply create or delete actions as needed
 
 ### Working with query history
-| Step | Action                                                                 |
-| ---- | ---------------------------------------------------------------------- |
-| 1    | Open Query History and filter by graph or search for a previous query. |
-| 2    | Select a query and review Metadata, Explain, or Profile.               |
+1. Open **Query History** and filter by graph or search for a previous query
+2. Select a query and review **Metadata**, **Explain**, or **Profile**
 
 [NEED GIF HERE]
 
 ### Exporting graph data
-| Step | Action                                      |
-| ---- | ------------------------------------------- |
-| 1    | Open graph management and select a graph.   |
-| 2    | Click Export Data to download a `.dump` file. |
+1. Open graph management and select a graph
+2. Click **Export Data** to download a `.dump` file
 
 [NEED GIF HERE]
 


### PR DESCRIPTION
Convert broken markdown tables to proper bullet lists and numbered lists for better readability and correct rendering.

Changes:
- Convert feature tables to bullet lists with sub-bullets
- Convert workflow steps to numbered lists
- Maintain all original content and structure

Co-Authored-By: Warp <agent@warp.dev>
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses markdown formatting inconsistencies in the Browser documentation, aiming to improve readability.

#### Key Changes
The primary change involves refactoring several feature description tables into more readable bulleted lists. This includes adding bullet points and bolding feature names for improved clarity and consistent documentation style.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 31 (32.6%)    |
| Churn       | 8 (8.4%)      |
| Rework      | 56 (58.9%)    |
| Total Changes | 95            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with improved formatting and structure for better readability. Converted tabular layouts to organized bullet-point lists across multiple sections, including graph exploration, querying, data manipulation, and settings. Applied consistent formatting and refined descriptions for clarity while preserving all content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->