### PR TITLE
Add front matter to falkordblite-py.md

### DIFF
--- a/operations/falkordblite/falkordblite-py.md
+++ b/operations/falkordblite/falkordblite-py.md
@@ -1,3 +1,4 @@
+---
 title: "FalkorDBLite (Python)"
 nav_order: 1
 parent: "FalkorDBLite"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR adds the opening delimiter for YAML front matter to the `falkordblite-py.md` documentation file, which is essential for proper metadata parsing by static site generators.

#### Key Changes
- Added `---` to the beginning of `operations/falkordblite/falkordblite-py.md` to define the start of the front matter block.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 1 (100.0%)    |
| Total Changes | 1         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation metadata for the FalkorDBLite Python module to improve organization and navigation within the documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->