### PR TITLE
Update index.md add redirect

### DIFF
--- a/operations/falkordblite/index.md
+++ b/operations/falkordblite/index.md
@@ -4,6 +4,9 @@ description: "Embedded FalkorDB runtime with Python and TypeScript bindings"
 nav_order: 6
 parent: "Operations"
 has_children: true
+redirect_from:
+  - /operations/falkordblite.html
+
 ---
 
 # FalkorDBLite


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR adds a redirect to the `operations/falkordblite/index.md` file to ensure that old links pointing to the `.html` version of the page are correctly redirected to the current Markdown file.

#### Key Changes
- Added `redirect_from` front matter to `operations/falkordblite/index.md`, specifying `/operations/falkordblite.html` to handle redirects from the old URL.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (100.0%)    |
| Total Changes | 3             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added automatic URL redirect configuration for legacy documentation paths. Users accessing outdated URLs will now be seamlessly redirected to the current documentation location. This enhancement ensures smooth navigation continuity when users share documentation links and references with colleagues, and effectively prevents broken links across all documentation resources and external communications channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->