### PR TITLE
fix #312 reorder menus

### DIFF
--- a/References/index.md
+++ b/References/index.md
@@ -2,7 +2,7 @@
 title: "References"
 description: "Explore FalkorDB resources including blog posts, videos, research papers, tutorials, and technical articles about graph databases, GraphBLAS, and performance benchmarks."
 has_children: true
-nav_order: 998
+nav_order: 999
 redirect_from:
   - /References.html
 ---

--- a/design/index.md
+++ b/design/index.md
@@ -2,7 +2,7 @@
 title: "The FalkorDB Design"
 description: "FalkorDB: A High Performance In-Memory Graph Database"
 has_children: true
-nav_order: 999
+nav_order: 998
 ---
 
 # The FalkorDB Design

--- a/integration/index.md
+++ b/integration/index.md
@@ -19,5 +19,6 @@ Learn how to leverage FalkorDB's flexible APIs and SDKs to build high-performanc
 - [Apache Jena](./jena.md): Learn how to use FalkorDB with Apache Jena via the jena-falkordb-adapter.
 - [BOLT protocol support](./bolt-support.md): Learn how to connect to FalkorDB using the BOLT protocol.
 - [Spring Data FalkorDB](./spring-data-falkordb.md): Learn how to use FalkorDB with Spring Data for JPA-style object-graph mapping.
+- [Snowflake Integration](./snowflake.md): Learn how to run graph database operations directly within your Snowflake environment using the FalkorDB Native App.
 
 

--- a/integration/snowflake.md
+++ b/integration/snowflake.md
@@ -1,3 +1,10 @@
+---
+title: "Snowflake Integration"
+nav_order: 6
+description: "Run graph database operations directly within your Snowflake environment using the FalkorDB Native App."
+parent: "Integration"
+---
+
 # FalkorDB Snowflake Integration Guide
 
 ## Overview


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR addresses issue #312 by reordering existing menu items and introducing a new documentation page for Snowflake integration.

#### Key Changes
- The navigation order for "References" and "The FalkorDB Design" menus has been swapped.
- A new documentation page for "Snowflake Integration" has been added, detailing how to run graph database operations within Snowflake.
- The `integration/index.md` file has been updated to include a link to the new Snowflake integration guide.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 8 (80.0%)     |
| Rework      | 2 (20.0%)     |
| Total Changes | 10          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized navigation structure to improve content discoverability.
  * Added new Snowflake Integration documentation with metadata and descriptive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->