### PR TITLE
Update index.md with port information for FalkorDB

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ docker run -p 6379:6379 -p 3000:3000 -it --rm falkordb/falkordb:latest
 
 ### Ports Exposed
 
-- **6379 (FalkorDB)**  
+- **6379 (FalkorDB Server)**  
   Use this port to connect via the CLI or any FalkorDB-compatible client.
 
 - **3000 (FalkorDB Browser)**  


### PR DESCRIPTION
Added details about exposed ports for FalkorDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Ports exposed" subsection in Get Started listing ports 6379 and 3000.
  * Added a Trendshift badge near the top of the page.
  * Introduced multi-language code samples (Python, JavaScript, Java, Rust, Shell) showing connection, graph creation, and basic queries.
  * Adjusted formatting to accommodate the new content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->