### PR TITLE
docs: update SQL-to-FalkorDB migration guide for latest feature set

### DIFF
--- a/operations/migration/sql-to-falkordb.md
+++ b/operations/migration/sql-to-falkordb.md
@@ -1,24 +1,26 @@
 ---
 title: "SQL Sources to FalkorDB (Online Migration)"
-description: "Online migration and incremental sync from SQL sources (ClickHouse, Databricks, MariaDB, MySQL, PostgreSQL, Snowflake, SQL Server) into FalkorDB using DM-SQL-to-FalkorDB loaders and control plane."
+description: "Online migration and incremental sync from SQL sources (BigQuery, ClickHouse, Databricks, MariaDB, MySQL, PostgreSQL, Snowflake, Spark SQL, SQL Server) into FalkorDB using DM-SQL-to-FalkorDB loaders and control plane."
 parent: "Migration"
 nav_order: 5
 ---
 
 # Online Data Migration from SQL Sources to FalkorDB
 
-The [DM-SQL-to-FalkorDB](https://github.com/FalkorDB/DM-SQL-to-FalkorDB) repository provides Rust-based CLI loaders to perform an initial load from SQL systems into FalkorDB and optionally keep FalkorDB continuously synchronized using incremental watermarks.
+The [DM-SQL-to-FalkorDB](https://github.com/FalkorDB/DM-SQL-to-FalkorDB) repository provides Rust-based CLI loaders for initial load and ongoing sync from SQL sources into FalkorDB.
 
-It also includes an optional control plane (web UI + REST API) for creating configurations, starting runs, monitoring progress, and viewing persisted metrics snapshots.
+It also includes an optional control plane (web UI + REST API) for config authoring, schema/template scaffolding, run orchestration, state management, and persisted metrics/log history.
 
 ## Supported sources
 
+- BigQuery
 - ClickHouse
 - Databricks (Databricks SQL / warehouses)
 - MariaDB
 - MySQL
 - PostgreSQL
 - Snowflake
+- Spark SQL (via Livy sessions)
 - SQL Server
 
 ## When to use this approach
@@ -31,11 +33,11 @@ Use these tools when you want:
 ## Prerequisites
 
 - Rust toolchain (Cargo)
-- Network access to your SQL source (ClickHouse, Databricks SQL warehouse, MariaDB, MySQL, PostgreSQL, Snowflake, or SQL Server)
+- Network access to your source system
 - A reachable FalkorDB endpoint (for example `falkor://127.0.0.1:6379`)
 - Node.js + npm (optional; only needed for control plane UI)
 
-Most configurations reference environment variables for secrets and credentials, for example: `$CLICKHOUSE_URL`, `$DATABRICKS_TOKEN`, `$MARIADB_URL`, `$MYSQL_URL`, `$POSTGRES_URL`, `$SNOWFLAKE_PASSWORD`, `$SQLSERVER_CONNECTION_STRING`.
+Configurations typically reference environment variables for credentials/secrets (for example `$BIGQUERY_ACCESS_TOKEN`, `$DATABRICKS_TOKEN`, `$MYSQL_URL`, `$POSTGRES_URL`, `$SNOWFLAKE_PASSWORD`, `$SPARK_AUTH_TOKEN`, `$SQLSERVER_CONNECTION_STRING`).
 
 ## Getting the tools
 
@@ -48,22 +50,39 @@ cd DM-SQL-to-FalkorDB
 
 Each loader uses JSON/YAML configuration to define:
 
-- How to read rows from the source (`table` + optional filter, or custom `SELECT`)
-- How rows map to:
+- How to read rows from the source (`table` + optional filter, or custom query)
+- How rows map to graph entities:
   - Nodes (labels, keys, property mappings)
-  - Edges (relationship type, direction, and endpoint matching rules)
-- Whether each mapping is full or incremental
+  - Edges (relationship type, direction, endpoint matching rules)
+- Per-mapping execution mode (`full` or `incremental`)
 - Optional soft-delete behavior
-- Where incremental state/watermarks are persisted (typically a file-backed `state.json`)
+- State backend for incremental watermarks (typically file-backed JSON)
 
 ### Common concepts
 
-- Declarative mapping: you define mappings, and the loader handles extraction + load.
-- Idempotent writes: loaders use Cypher `UNWIND` + `MERGE` patterns.
-- Incremental safety: watermarks advance only after successful writes.
-- Restart safety: after failures, reruns continue from the last successful watermark.
+- Declarative mapping: mappings define extraction + graph writes.
+- Idempotent writes: loaders use Cypher `UNWIND` + `MERGE`.
+- Incremental safety: watermarks move only after successful writes.
+- Restart safety: failed runs can resume from persisted state.
+- Index handling: loaders apply explicit `falkordb.indexes` plus inferred indexes for node keys and edge endpoint matches.
+- Observability: loaders expose Prometheus-style metrics with global and per-mapping counters.
 
 ## Option A: Run a loader directly (CLI)
+
+### BigQuery → FalkorDB
+
+- Docs: [BigQuery-to-FalkorDB/README.md](https://github.com/FalkorDB/DM-SQL-to-FalkorDB/tree/main/BigQuery-to-FalkorDB)
+
+```bash
+cd BigQuery-to-FalkorDB/bigquery-to-falkordb
+cargo build --release
+
+# One-shot run
+cargo run --release -- --config ../bigquery_sample.yaml
+
+# Continuous sync
+cargo run --release -- --config ../bigquery_sample.yaml --daemon --interval-secs 60
+```
 
 ### ClickHouse → FalkorDB
 
@@ -90,7 +109,7 @@ cargo build --release
 cargo run --release -- --config path/to/config.yaml
 ```
 
-Note: this loader currently supports one-shot execution (no daemon/purge flags in the manifest).
+Note: Databricks currently supports one-shot runs only (no daemon/purge flags).
 
 ### MariaDB → FalkorDB
 
@@ -137,6 +156,8 @@ cargo run --release -- --config path/to/config.yaml
 cargo run --release -- --config path/to/config.yaml --daemon --interval-secs 60
 ```
 
+Note: PostgreSQL currently supports daemon mode but not purge flags.
+
 ### Snowflake → FalkorDB
 
 - Docs: [Snowflake-to-FalkorDB/README.md](https://github.com/FalkorDB/DM-SQL-to-FalkorDB/tree/main/Snowflake-to-FalkorDB)
@@ -151,6 +172,18 @@ cargo run --release -- --config path/to/config.yaml
 # Continuous sync
 cargo run --release -- --config path/to/config.yaml --daemon --interval-secs 300
 ```
+
+### Spark SQL (Livy) → FalkorDB
+
+- Docs: [Spark-to-FalkorDB/README.md](https://github.com/FalkorDB/DM-SQL-to-FalkorDB/tree/main/Spark-to-FalkorDB)
+
+```bash
+cd Spark-to-FalkorDB/spark-to-falkordb
+cargo build --release
+cargo run --release -- --config path/to/config.yaml
+```
+
+Note: Spark currently supports one-shot runs only (no daemon/purge flags).
 
 ### SQL Server → FalkorDB
 
@@ -167,7 +200,9 @@ cargo run --release -- --config sqlserver.incremental.yaml
 cargo run --release -- --config sqlserver.incremental.yaml --daemon --interval-secs 60
 ```
 
-Optional purge modes (supported by ClickHouse, MariaDB, MySQL, Snowflake, and SQL Server):
+### Optional purge modes
+
+Purge flags are supported by: BigQuery, ClickHouse, MariaDB, MySQL, Snowflake, SQL Server.
 
 ```bash
 # Purge full graph before loading
@@ -177,17 +212,36 @@ cargo run --release -- --config path/to/config.yaml --purge-graph
 cargo run --release -- --config path/to/config.yaml --purge-mapping customers
 ```
 
+## Schema introspection + template scaffolding
+
+Supported by: BigQuery, ClickHouse, Databricks, MariaDB, MySQL, PostgreSQL, Snowflake, Spark, SQL Server.
+
+```bash
+# Print normalized source schema summary
+cargo run --release -- --config path/to/config.yaml --introspect-schema
+
+# Generate starter mapping template
+cargo run --release -- --config path/to/config.yaml --generate-template --output scaffold.yaml
+```
+
+Notes:
+
+- Generated templates are scaffolds and should be reviewed before production use.
+- For tools that support daemon/purge modes, scaffold flags cannot be combined with daemon/purge flags in the same run.
+
 ## Option B: Use the control plane (web UI + API)
 
-The control plane discovers tools by scanning for `tool.manifest.json` files and provides a UI/API to:
+The control plane discovers tools by scanning for `tool.manifest.json` and provides UI/API features to:
 
 - Create and edit per-tool YAML/JSON configurations
-- Start runs (one-shot or daemon where supported)
-- Stop running jobs
-- Stream logs live (SSE)
-- Store run history and artifacts (SQLite + file-backed data directory)
-- Auto-wire tool metrics ports for metrics-capable tools
-- Persist per-tool/per-mapping metrics snapshots
+- Preview extracted source schema
+- Generate scaffold templates from source metadata
+- Visualize graph topology from mappings
+- Start runs (one-shot and daemon where supported)
+- Stop active runs
+- Stream live logs (SSE) and view persisted logs for historical runs
+- Inspect and clear per-config incremental state/watermarks
+- Persist and view per-tool/per-mapping metrics snapshots in SQLite
 
 Start the server:
 
@@ -210,17 +264,27 @@ Configuration (environment variables):
 - `CONTROL_PLANE_UI_DIST` (default `control-plane/ui/dist/`)
 - `CONTROL_PLANE_API_KEY` (optional bearer token requirement)
 
-Selected metrics API endpoints:
+Selected API endpoints:
 
-- `GET /api/metrics`
-- `GET /api/metrics/:tool_id`
+- `GET /api/health`
+- `GET /api/tools`, `GET /api/tools/:tool_id`
+- `POST /api/tools/:tool_id/scaffold-template`
+- `POST /api/tools/:tool_id/schema-graph-preview`
+- `GET /api/configs`, `POST /api/configs`
+- `GET /api/configs/:config_id`, `PUT /api/configs/:config_id`
+- `GET /api/configs/:config_id/state`, `POST /api/configs/:config_id/state/clear`
+- `GET /api/runs`, `POST /api/runs`
+- `GET /api/runs/:run_id`, `POST /api/runs/:run_id/stop`
+- `GET /api/runs/:run_id/events` (SSE)
+- `GET /api/runs/:run_id/logs`
+- `GET /api/metrics` (optional `?config_id=<uuid>`)
+- `GET /api/metrics/:tool_id` (optional `?config_id=<uuid>`)
 
 Notes:
 
-- Runs execute locally on the machine hosting the control plane server.
-- Log streaming uses SSE.
-- For `supports_metrics: true` tools, the control plane injects `--metrics-port` and persists snapshots in SQLite.
-- The Metrics UI uses persisted snapshots and does not expose internal scrape endpoint/port settings.
+- Runs execute locally on the host machine running the control plane server.
+- Runtime artifacts are persisted under `CONTROL_PLANE_DATA_DIR`, including a SQLite DB and per-run files.
+- SSE auth with API key may use query-string token fallback because browser `EventSource` does not support custom auth headers.
 
 UI development (optional):
 
@@ -230,20 +294,7 @@ npm install
 npm run dev
 ```
 
-**Screenshots:**
-The main tools menu with migration selection options.
-<img width="1403" height="832" alt="DM-UI-7-tools" src="https://github.com/user-attachments/assets/e0100f17-caa0-495c-8914-e4a38ab44fc9" />
-
-The following example shows how you manually execute a migration run, with visibility to the latest incremental watermark, and an option to clear it to restart incremental migration from scratch.
-<img width="1422" height="861" alt="DM-UI--screenshot" src="https://github.com/user-attachments/assets/0c622f06-7b03-454c-a693-cd302d057343" />
-
-The following example shows the log view after a successful run.
-<img width="1422" height="861" alt="DM-UI--logs" src="https://github.com/user-attachments/assets/e0b2c286-b857-44d4-887d-3aa3664744b9" />
-
-The following shows the metrics view summarizing a run:
-<img width="1403" height="832" alt="DM-UI--metrics" src="https://github.com/user-attachments/assets/af09d6ff-c1ed-4148-b1ab-6fa2500887dc" />
-
-## Metrics feature (all SQL loaders)
+## Metrics feature
 
 All current SQL loaders expose Prometheus-style metrics with:
 
@@ -262,22 +313,25 @@ All current SQL loaders expose Prometheus-style metrics with:
 
 Default metrics ports:
 
+- BigQuery: `9995`
 - ClickHouse: `9991`
 - Databricks: `9994`
 - MariaDB: `9997`
 - MySQL: `9995`
 - PostgreSQL: `9993`
 - Snowflake: `9992`
+- Spark: `9997`
 - SQL Server: `9996`
 
-You can override ports with `--metrics-port` (or each tool's corresponding environment variable).
+Use `--metrics-port` (or each loader’s corresponding `*_TO_FALKORDB_METRICS_PORT` environment variable) to override defaults, especially when running multiple loaders concurrently.
 
 ## Operational tips
 
 - Define node mappings before edge mappings (edges depend on nodes).
 - Choose stable keys for `MERGE` (primary keys are usually best).
+- Treat scaffold-generated mappings as a starting point; always review relationship semantics and incremental/delete logic.
 - Use `RUST_LOG=info` (or `debug`) for richer loader diagnostics.
-- Keep state and control-plane data on durable storage for long-running sync setups.
+- Keep state files and control-plane data on durable storage for long-running sync setups.
 
 ## Additional resources
 


### PR DESCRIPTION
## Summary
- refresh `operations/migration/sql-to-falkordb.md` to match current DM-SQL-to-FalkorDB capabilities
- add BigQuery and Spark SQL (Livy) source coverage
- align connector capability notes (daemon/purge/scaffold support)
- update control-plane section with current API endpoints and persisted state/log/metrics behavior
- refresh metrics defaults and operational guidance

## Validation
- reviewed content against current loader manifests, README files, and CLI flags in source

## Artifacts
- Conversation: https://app.warp.dev/conversation/59f808d8-776e-4db0-87c7-122c7a41c92e

Co-Authored-By: Oz <oz-agent@warp.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support for BigQuery and Spark SQL as migration sources.
  * Introduced schema introspection and template scaffolding CLI commands (`--introspect-schema`, `--generate-template`).
  * Expanded control plane capabilities including schema preview, graph topology visualization, state inspection, and persisted logs.
  * Enhanced metrics and observability features for all supported data sources.
  * Added loader-specific run mode guidance and operational best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->