### PR TITLE
docs(config): enable back-to-top button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ favicon_ico: "/images/favicon.ico"
 gtm_tracking: GTM-MBWB627H
 
 heading_anchors: true
+back_to_top: true
+back_to_top_text: "Back to top"
 
 search_enabled: true
 color_scheme: dark


### PR DESCRIPTION
## Summary
Enable the built-in Just the Docs floating "Back to top" button on all pages, improving navigation on long reference pages.

## Changes
- Added `back_to_top: true` to `_config.yml`
- Added `back_to_top_text: "Back to top"` to `_config.yml`

## Testing
Jekyll config syntax verified. This is a built-in JtD feature requiring no custom code.

## Memory / Performance Impact
N/A

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled a "Back to top" UI control so users can quickly return to the top of pages. The control includes a configurable label text (default: "Back to top") to match site wording and accessibility needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->