### PR TITLE
feat(theme): add FalkorDB-branded custom dark color scheme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ gtm_tracking: GTM-MBWB627H
 heading_anchors: true
 
 search_enabled: true
-color_scheme: dark
+color_scheme: falkordb-dark
 
 aux_links:
   "Docs Repository":

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -24,7 +24,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   padding: 0.75rem 1rem;
   font-size: 0.75rem;
   line-height: 1.4;
-  border-left: 1px solid var(--sidebar-color, #44434d);
+  border-left: 1px solid var(--border-color, #44434d);
   z-index: 100;
 }
 
@@ -91,7 +91,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   width: 3px;
 }
 .toc-sidebar::-webkit-scrollbar-thumb {
-  background: var(--sidebar-color, #44434d);
+  background: var(--border-color, #44434d);
   border-radius: 3px;
 }
 </style>

--- a/_sass/color_schemes/falkordb-dark.scss
+++ b/_sass/color_schemes/falkordb-dark.scss
@@ -1,4 +1,4 @@
-@import "./color_schemes/dark";
+@import "color_schemes/dark";
 
 // FalkorDB brand color scheme
 // Based on the dark scheme with purple/magenta accents to match FalkorDB branding

--- a/_sass/color_schemes/falkordb-dark.scss
+++ b/_sass/color_schemes/falkordb-dark.scss
@@ -1,0 +1,26 @@
+@import "./color_schemes/dark";
+
+// FalkorDB brand color scheme
+// Based on the dark scheme with purple/magenta accents to match FalkorDB branding
+
+// Brand palette
+$falkordb-purple: #a78bfa;
+$falkordb-purple-dark: #7c3aed;
+$falkordb-purple-deeper: #4e26af;
+$falkordb-bg: #1b1f23;
+$falkordb-sidebar-bg: #161a1f;
+$falkordb-surface: #2d333b;
+
+// Core overrides
+$body-background-color: $falkordb-bg;
+$sidebar-color: $falkordb-sidebar-bg;
+$body-text-color: #e0e0e0;
+$link-color: $falkordb-purple;
+$nav-child-link-color: #9ca3af;
+$btn-primary-color: $falkordb-purple-dark;
+$search-background-color: $falkordb-surface;
+$code-background-color: $falkordb-surface;
+$feedback-color: darken($falkordb-sidebar-bg, 3%);
+$table-background-color: $falkordb-surface;
+$border-color: #3d434b;
+$base-button-color: $falkordb-surface;


### PR DESCRIPTION
## Summary
Replace the generic JtD dark color scheme with a custom FalkorDB-branded dark scheme using the brand's purple/magenta palette.

## Changes
- **New file**: `_sass/color_schemes/falkordb-dark.scss` — extends the JtD dark scheme with FalkorDB brand colors
- **`_config.yml`**: Updated `color_scheme: dark` → `color_scheme: falkordb-dark`

### Color Palette
| Element | Before (JtD dark) | After (FalkorDB) |
|---------|--------------------|-------------------|
| Links | `#5c9cf5` (blue) | `#a78bfa` (purple) |
| Buttons | `#264caf` (blue) | `#7c3aed` (purple) |
| Background | `#27262b` (gray) | `#1b1f23` (charcoal) |
| Sidebar | `#27262b` (gray) | `#161a1f` (near-black) |
| Code/Search bg | `#302d36` (gray) | `#2d333b` (subtle) |

## Testing
Custom color schemes are a standard JtD feature. The SCSS file imports the base dark scheme and overrides specific variables.

## Memory / Performance Impact
N/A

## Related Issues
N/A