### PR TITLE
fix(toc): remove margin-right that squeezed main content

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -76,13 +76,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   }
 }
 
-/* Reduce main content max-width when TOC is visible */
-@media (min-width: 1201px) {
-  .main-content-wrap {
-    margin-right: 250px;
-  }
-}
-
 /* Scrollbar styling */
 .toc-sidebar::-webkit-scrollbar {
   width: 3px;


### PR DESCRIPTION
## Summary
The sticky TOC sidebar uses `position: fixed` and overlays the page naturally. The `margin-right: 250px` on `.main-content-wrap` was unnecessarily squeezing the main content area, making it too narrow.

## Changes
- Removed the `@media (min-width: 1201px)` rule that added `margin-right: 250px` to `.main-content-wrap`

## Testing
The TOC sidebar is fixed-position and sits on top of the page — it doesn't participate in the document flow, so no margin is needed.

## Memory / Performance Impact
N/A

## Related Issues
Follows up on PR #412