### PR TITLE
feat(homepage): replace banner with text-based hero and CTA buttons

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Home
 nav_order: 1
-description: "The fastest way to your knowledge"
+description: "FalkorDB Docs — The graph database for accurate GenAI with GraphRAG at scale"
 permalink: /
 ---
 

--- a/index.md
+++ b/index.md
@@ -8,6 +8,8 @@ permalink: /
 
 # FalkorDB Documentation
 
+[![Trendshift](https://trendshift.io/api/badge/repositories/14787)](https://trendshift.io/repositories/14787)
+
 [![Docker Hub](https://img.shields.io/docker/pulls/falkordb/falkordb?label=Docker&style=flat-square)](https://hub.docker.com/r/falkordb/falkordb/)
 [![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
 [![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)

--- a/index.md
+++ b/index.md
@@ -8,6 +8,10 @@ permalink: /
 
 # FalkorDB Documentation
 
+[![Docker Hub](https://img.shields.io/docker/pulls/falkordb/falkordb?label=Docker&style=flat-square)](https://hub.docker.com/r/falkordb/falkordb/)
+[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
+[![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)
+
 The graph platform developers use to build accurate GenAI with GraphRAG at scale.
 {: .fs-6 .fw-300 }
 
@@ -265,9 +269,3 @@ Got questions? Please contact us at the [FalkorDB forum](https://github.com/Falk
 ## License
 
 FalkorDB is licensed under the [the Server Side Public License v1 (SSPLv1)](https://github.com/FalkorDB/FalkorDB/blob/master/LICENSE.txt).
-
----
-
-[![Docker Hub](https://img.shields.io/docker/pulls/falkordb/falkordb?label=Docker&style=flat-square)](https://hub.docker.com/r/falkordb/falkordb/)
-[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
-[![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)

--- a/index.md
+++ b/index.md
@@ -14,6 +14,8 @@ permalink: /
 [![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
 [![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)
 
+<img src="https://github.com/user-attachments/assets/201b07e1-ac6d-4593-98cf-e58946d7766c" alt="FalkorDB — Build Fast and Accurate GenAI with GraphRAG at Scale" style="max-width: 600px; width: 100%;" />
+
 The graph platform developers use to build accurate GenAI with GraphRAG at scale.
 {: .fs-6 .fw-300 }
 

--- a/index.md
+++ b/index.md
@@ -2,11 +2,10 @@
 layout: default
 title: Home
 nav_order: 1
-description: "FalkorDB Documentation — The Graph platform for GenAI with GraphRAG at Scale"
+description: "The fastest way to your knowledge"
 permalink: /
 ---
 
-# FalkorDB Documentation
 
 [![Trendshift](https://trendshift.io/api/badge/repositories/14787)](https://trendshift.io/repositories/14787)
 
@@ -14,15 +13,10 @@ permalink: /
 [![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
 [![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)
 
-<img src="https://github.com/user-attachments/assets/201b07e1-ac6d-4593-98cf-e58946d7766c" alt="FalkorDB — Build Fast and Accurate GenAI with GraphRAG at Scale" style="max-width: 600px; width: 100%;" />
+![FalkorDB Docs Readme Banner](https://github.com/user-attachments/assets/201b07e1-ac6d-4593-98cf-e58946d7766c)
 
-The graph platform developers use to build accurate GenAI with GraphRAG at scale.
-{: .fs-6 .fw-300 }
-
-[Get Started](/getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[GraphRAG SDK](/genai-tools/graphrag-sdk){: .btn .fs-5 .mb-4 .mb-md-0 }
-
----
+# FalkorDB
+## The Graph platform developers use to achieve accurate GraphRAG for enterprise GenAI
 
 ## About FalkorDB
 

--- a/index.md
+++ b/index.md
@@ -2,31 +2,30 @@
 layout: default
 title: Home
 nav_order: 1
-description: "The fastest way to your knowledge"
+description: "FalkorDB Documentation — The Graph platform for GenAI with GraphRAG at Scale"
 permalink: /
 ---
 
+# FalkorDB Documentation
 
+The graph platform developers use to build accurate GenAI with GraphRAG at scale.
+{: .fs-6 .fw-300 }
 
-[![Trendshift](https://trendshift.io/api/badge/repositories/14787)](https://trendshift.io/repositories/14787)
+[Get Started](/getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[GraphRAG SDK](/genai-tools/graphrag-sdk){: .btn .fs-5 .mb-4 .mb-md-0 }
 
-[![Docker Hub](https://img.shields.io/docker/pulls/falkordb/falkordb?label=Docker&style=flat-square)](https://hub.docker.com/r/falkordb/falkordb/)
-[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E) 
-[![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)
-
-![FalkorDB Docs Readme Banner](https://github.com/user-attachments/assets/201b07e1-ac6d-4593-98cf-e58946d7766c)
-
-# FalkorDB
-## The Graph platform developers use to achieve accurate GraphRAG for enterprise GenAI
+---
 
 ## About FalkorDB
-FalkorDB delivers an **accurate, multi-tenant RAG solution powered by a low-latency, scalable graph database technology.** 
 
-* Our solution is purpose-built for development teams working with complex, interconnected data—whether structured or unstructured—in real-time or interactive user environments.
+FalkorDB delivers an **accurate, multi-tenant RAG solution powered by a low-latency, scalable graph database technology.**
 
-* The system supports the OpenCypher query language with proprietary enhancements that streamline interactions with graph data. Its efficient graph traversal and query capabilities make it well-suited for production environments.
+* Purpose-built for development teams working with complex, interconnected data—whether structured or unstructured—in real-time or interactive user environments.
+
+* Supports the OpenCypher query language with proprietary enhancements that streamline interactions with graph data. Its efficient graph traversal and query capabilities make it well-suited for production environments.
 
 ## Choose Your Path
+
 *   **Graph Database Path:** If you're interested in using FalkorDB as a property graph database with OpenCypher support, continue with the sections below.
 *   **GraphRAG Path:** If you're aiming to implement advanced graph reasoning and generative AI tasks, explore our [GenAI Tools](/genai-tools) section, starting with the [GraphRAG SDK](/genai-tools/graphrag-sdk).
 
@@ -266,3 +265,9 @@ Got questions? Please contact us at the [FalkorDB forum](https://github.com/Falk
 ## License
 
 FalkorDB is licensed under the [the Server Side Public License v1 (SSPLv1)](https://github.com/FalkorDB/FalkorDB/blob/master/LICENSE.txt).
+
+---
+
+[![Docker Hub](https://img.shields.io/docker/pulls/falkordb/falkordb?label=Docker&style=flat-square)](https://hub.docker.com/r/falkordb/falkordb/)
+[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
+[![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)


### PR DESCRIPTION
## Summary
Replaces the giant marketing banner image and badges at the top of the homepage with a clean, text-based hero section using JtD's built-in button utilities.

## Changes
- Remove the 1500×526px marketing banner image that pushed content below the fold
- Remove the Trendshift badge from the top
- Add a clean hero with descriptive subtitle and two CTA buttons:
  - **Get Started** (`.btn-primary`) → `/getting-started/`
  - **GraphRAG SDK** (`.btn`) → `/genai-tools/graphrag-sdk`
- Update the `description` meta to be more SEO-friendly
- Move Docker Hub, Discord, and Try Free badges to the page footer
- All existing content (About, Features, Get Started, code examples) is preserved

## Testing
- Verified markdown renders correctly
- Spellcheck should pass (no new words added)

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined markdown formatting by removing unnecessary whitespace and adjusting line breaks for improved readability and visual consistency throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->