### PR TITLE
docs(acl): document fine-grained graph permissions

### DIFF
--- a/commands/acl.md
+++ b/commands/acl.md
@@ -114,6 +114,48 @@ Usage: `ACL LIST`
 3) "guest"
 ```
 
+### Key permissions
+
+In addition to the basic `~<pattern>` rule, ACL supports fine-grained per-key
+permissions that restrict how a command is allowed to touch a matching key.
+Key permission rules take the form `%(<permission>)~<pattern>`, where
+`<permission>` is one or more of the following characters:
+
+* `W` (Write): The data stored within the key may be updated or deleted.
+* `R` (Read): User-supplied data from the key is processed, copied or returned.
+  This does not include metadata such as size information (for example
+  `STRLEN`), type information (for example `TYPE`), or whether a value exists
+  within a collection (for example `SISMEMBER`).
+
+Permissions can be composed by specifying multiple characters. `%RW~<pattern>`
+is full access and is equivalent to plain `~<pattern>`.
+
+#### Example
+
+Consider a user with the rules `+@all ~app1:* (+@read ~app2:*)`. This grants
+full access on `app1:*` and read-only access on `app2:*`. However, commands
+such as `COPY` read from a source key and write to a destination key, so a
+request to copy `app2:user` into `app1:user` would be rejected because neither
+the root permission nor the selector fully matches the command. Using key
+permissions, the rule set `+@all ~app1:* %R~app2:*` handles this case: the
+first pattern matches the destination key with write access and the second
+pattern matches the source key with read access.
+
+#### Notes
+
+* Whether a command requires read or write permission on a key is derived from
+  the command's key specifications. Insert, update, and delete flags map to
+  the write permission; the access flag maps to the read permission. Commands
+  with no logical operation flags (for example `EXISTS`) require either read
+  or write permission on the key to execute.
+* Side channels to user data are not considered when evaluating read
+  permissions. For example, `LPUSH key1 data` modifies `key1` but only returns
+  metadata (the new list size), so it requires only write permission on
+  `key1`. `LPOP key2` modifies `key2` and also returns data from it (the
+  left-most item), so it requires both read and write permission on `key2`.
+  If an application needs to ensure no data is accessed from a key, including
+  via side channels, do not grant any access to the key.
+
 ### ACL LOG
 
 Displays a log of recent ACL-related events, such as user authentication attempts or rule changes.

--- a/commands/acl.md
+++ b/commands/acl.md
@@ -114,18 +114,19 @@ Usage: `ACL LIST`
 3) "guest"
 ```
 
-### Key permissions
+### Graph permissions
 
-In addition to the basic `~<pattern>` rule, ACL supports fine-grained per-key
-permissions that restrict how a command is allowed to touch a matching key.
-Key permission rules take the form `%(<permission>)~<pattern>`, where
+In addition to the basic `~<pattern>` rule, ACL supports fine-grained
+permissions that restrict how a command is allowed to touch a matching graph.
+Graph permission rules take the form `%(<permission>)~<pattern>`, where
 `<permission>` is one or more of the following characters:
 
-* `W` (Write): The data stored within the key may be updated or deleted.
-* `R` (Read): User-supplied data from the key is processed, copied or returned.
-  This does not include metadata such as size information (for example
-  `STRLEN`), type information (for example `TYPE`), or whether a value exists
-  within a collection (for example `SISMEMBER`).
+* `W` (Write): Data stored within the graph may be updated or deleted (for
+  example by `GRAPH.QUERY` running a write Cypher clause, or `GRAPH.DELETE`).
+* `R` (Read): Data from the graph is returned to the client (for example by
+  `GRAPH.RO_QUERY`, or by `GRAPH.QUERY` running a read-only Cypher clause).
+  This does not include graph-level metadata such as the list of existing
+  graphs returned by `GRAPH.LIST`.
 
 Permissions can be composed by specifying multiple characters. `%RW~<pattern>`
 is full access and is equivalent to plain `~<pattern>`.
@@ -133,28 +134,29 @@ is full access and is equivalent to plain `~<pattern>`.
 #### Example
 
 Consider a user with the rules `+@all ~app1:* (+@read ~app2:*)`. This grants
-full access on `app1:*` and read-only access on `app2:*`. However, commands
-such as `COPY` read from a source key and write to a destination key, so a
-request to copy `app2:user` into `app1:user` would be rejected because neither
-the root permission nor the selector fully matches the command. Using key
-permissions, the rule set `+@all ~app1:* %R~app2:*` handles this case: the
-first pattern matches the destination key with write access and the second
-pattern matches the source key with read access.
+full access on graphs matching `app1:*` and a separate read-only selector for
+graphs matching `app2:*`. However, `GRAPH.COPY` reads from a source graph and
+writes to a destination graph, so a request to copy `app2:users` into
+`app1:users` would be rejected because neither the root permission nor the
+selector matches both graphs at once. Using graph permissions, the rule set
+`+@all ~app1:* %R~app2:*` handles this case: the first pattern matches the
+destination graph with write access and the second pattern matches the source
+graph with read access.
 
 #### Notes
 
-* Whether a command requires read or write permission on a key is derived from
-  the command's key specifications. Insert, update, and delete flags map to
-  the write permission; the access flag maps to the read permission. Commands
-  with no logical operation flags (for example `EXISTS`) require either read
-  or write permission on the key to execute.
-* Side channels to user data are not considered when evaluating read
-  permissions. For example, `LPUSH key1 data` modifies `key1` but only returns
-  metadata (the new list size), so it requires only write permission on
-  `key1`. `LPOP key2` modifies `key2` and also returns data from it (the
-  left-most item), so it requires both read and write permission on `key2`.
-  If an application needs to ensure no data is accessed from a key, including
-  via side channels, do not grant any access to the key.
+* Whether a command requires read or write permission on a graph is derived
+  from the command's key specifications. Insert, update, and delete flags map
+  to the write permission; the access flag maps to the read permission.
+  Commands that operate on a graph without a defined logical operation flag
+  still require either read or write permission on the graph to execute.
+* Side channels to graph data are not considered when evaluating read
+  permissions. A command that mutates a graph but only returns metadata about
+  the mutation (for example, the count of nodes affected) requires only write
+  permission, while a command that mutates a graph and also returns data from
+  it requires both read and write permission. If an application must ensure
+  that no data is read from a graph, including via side channels, do not
+  grant any access to that graph.
 
 ### ACL LOG
 

--- a/commands/acl.md
+++ b/commands/acl.md
@@ -50,8 +50,55 @@ Usage: `ACL SETUSER <username> [rule1] [rule2] ...`
     * nopass: Allows access without a password.
     * password:<password>: Sets a password for the user.
     * ~<pattern>: Restricts access to graphs matching the given pattern.
+    * %<permission>~<pattern>: Restricts access to graphs matching the given pattern with fine-grained read/write permissions. See [Graph permissions](#graph-permissions) below.
     * +<command>: Grants permission to execute specific commands.
     * -<command>: Denies permission to execute specific commands.
+
+#### Graph permissions
+
+In addition to the basic `~<pattern>` rule, ACL supports fine-grained
+permissions that restrict how a command is allowed to touch a matching graph.
+Graph permission rules take the form `%<permission>~<pattern>`, where
+`<permission>` is one or more of the following characters:
+
+* `W` (Write): Data stored within the graph may be updated or deleted (for
+  example by `GRAPH.QUERY` running a write Cypher clause, or `GRAPH.DELETE`).
+* `R` (Read): Data from the graph is returned to the client (for example by
+  `GRAPH.RO_QUERY`, or by `GRAPH.QUERY` running a read-only Cypher clause).
+  This does not include graph-level metadata such as the list of existing
+  graphs returned by `GRAPH.LIST`.
+
+Permissions can be composed by specifying multiple characters. `%RW~<pattern>`
+is full access and is equivalent to plain `~<pattern>`.
+
+##### Example
+
+The basic `~<pattern>` rule grants the same level of access to every matching
+graph, so it cannot express different permissions for different graphs that
+appear in the same command. For instance, `GRAPH.COPY` reads from a source
+graph and writes to a destination graph: with the rules `+@all ~app1:*` alone
+there is no way to allow copying from a graph in `app2:*` into `app1:users`
+while keeping `app2:*` read-only.
+
+Using graph permissions, the rule set `+@all ~app1:* %R~app2:*` handles this
+case: the first pattern matches the destination graph (`app1:users`) with full
+access and the second pattern matches the source graph (`app2:users`) with
+read-only access.
+
+##### Notes
+
+* Whether a command requires read or write permission on a graph is derived
+  from the command's key specifications. Insert, update, and delete flags map
+  to the write permission; the access flag maps to the read permission.
+  Commands that operate on a graph without a defined logical operation flag
+  still require either read or write permission on the graph to execute.
+* Side channels to graph data are not considered when evaluating read
+  permissions. A command that mutates a graph but only returns metadata about
+  the mutation (for example, the count of nodes affected) requires only write
+  permission, while a command that mutates a graph and also returns data from
+  it requires both read and write permission. If an application must ensure
+  that no data is read from a graph, including via side channels, do not
+  grant any access to that graph.
 
 #### Example
 
@@ -113,50 +160,6 @@ Usage: `ACL LIST`
 2) "john"
 3) "guest"
 ```
-
-### Graph permissions
-
-In addition to the basic `~<pattern>` rule, ACL supports fine-grained
-permissions that restrict how a command is allowed to touch a matching graph.
-Graph permission rules take the form `%(<permission>)~<pattern>`, where
-`<permission>` is one or more of the following characters:
-
-* `W` (Write): Data stored within the graph may be updated or deleted (for
-  example by `GRAPH.QUERY` running a write Cypher clause, or `GRAPH.DELETE`).
-* `R` (Read): Data from the graph is returned to the client (for example by
-  `GRAPH.RO_QUERY`, or by `GRAPH.QUERY` running a read-only Cypher clause).
-  This does not include graph-level metadata such as the list of existing
-  graphs returned by `GRAPH.LIST`.
-
-Permissions can be composed by specifying multiple characters. `%RW~<pattern>`
-is full access and is equivalent to plain `~<pattern>`.
-
-#### Example
-
-Consider a user with the rules `+@all ~app1:* (+@read ~app2:*)`. This grants
-full access on graphs matching `app1:*` and a separate read-only selector for
-graphs matching `app2:*`. However, `GRAPH.COPY` reads from a source graph and
-writes to a destination graph, so a request to copy `app2:users` into
-`app1:users` would be rejected because neither the root permission nor the
-selector matches both graphs at once. Using graph permissions, the rule set
-`+@all ~app1:* %R~app2:*` handles this case: the first pattern matches the
-destination graph with write access and the second pattern matches the source
-graph with read access.
-
-#### Notes
-
-* Whether a command requires read or write permission on a graph is derived
-  from the command's key specifications. Insert, update, and delete flags map
-  to the write permission; the access flag maps to the read permission.
-  Commands that operate on a graph without a defined logical operation flag
-  still require either read or write permission on the graph to execute.
-* Side channels to graph data are not considered when evaluating read
-  permissions. A command that mutates a graph but only returns metadata about
-  the mutation (for example, the count of nodes affected) requires only write
-  permission, while a command that mutates a graph and also returns data from
-  it requires both read and write permission. If an application must ensure
-  that no data is read from a graph, including via side channels, do not
-  grant any access to that graph.
 
 ### ACL LOG
 


### PR DESCRIPTION
## Summary
Adds documentation to `commands/acl.md` for FalkorDB's fine-grained per-graph ACL permissions, mirroring the equivalent rule from upstream Redis ACL but reframed in graph terminology.

## Changes
- `commands/acl.md`: new `#### Graph permissions` subsection under `### ACL SETUSER`, covering:
  - `%<permission>~<pattern>` syntax and composition
  - `W` (Write) and `R` (Read) semantics, with FalkorDB examples (`GRAPH.QUERY`, `GRAPH.RO_QUERY`, `GRAPH.DELETE`, `GRAPH.LIST`)
  - A `GRAPH.COPY`-motivated example: `+@all ~app1:* %R~app2:*`
  - How required permissions are derived from key specifications
  - Side-channel caveat for commands that mutate a graph and also return data
- New rule entry in the `#### Rules` list with a link to the new subsection.

## Testing
Documentation-only change. Spellcheck passes for `commands/acl.md`.

## Memory / Performance Impact
N/A — docs only.

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support docs for a new per-graph ACL rule format to grant explicit read (R) and write (W) permissions, including composable permissions (e.g., RW).
  * Added examples showing differing source vs. destination graph permissions in multi-target commands.
  * Clarified how commands derive read/write requirements and noted that side-channel graph data is excluded from read checks; guidance on preventing any graph reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->