### PR TITLE
docs(operations,design): add architecture diagrams for cluster, replication, and concurrency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,10 @@ plugins:
   - jekyll-redirect-from
   - jekyll-seo-tag
 
+# Enable Mermaid diagram rendering in fenced code blocks (```mermaid ... ```)
+mermaid:
+  version: "10.9.1"
+
 exclude:
   - README.md
   - Gemfile

--- a/design/concurrency.md
+++ b/design/concurrency.md
@@ -10,6 +10,39 @@ nav_order: 5
 
 This page describes how FalkorDB handles atomicity within individual queries and concurrency when multiple clients issue queries simultaneously.
 
+## Concurrency Model at a Glance
+
+FalkorDB uses a per-graph reader-writer model: many read queries can run in parallel against the same graph, while write queries are serialized so that only one write executes at a time on a given graph. Readers always observe a consistent snapshot of the graph as it existed when the read began — they never see partial state from an in-flight write.
+
+```mermaid
+flowchart LR
+    subgraph Clients["Concurrent clients"]
+        C1(["Reader A"])
+        C2(["Reader B"])
+        C3(["Reader C"])
+        W1(["Writer X"])
+        W2(["Writer Y"])
+    end
+
+    subgraph Engine["FalkorDB engine (per graph)"]
+        direction TB
+        TP["Thread pool<br/>(THREAD_COUNT)"]
+        WQ["Write queue<br/>(serialized, FIFO)"]
+        G[("Graph")]
+
+        TP -- "parallel reads<br/>(snapshot view)" --> G
+        WQ -- "one writer at a time<br/>(exclusive)" --> G
+    end
+
+    C1 --> TP
+    C2 --> TP
+    C3 --> TP
+    W1 --> WQ
+    W2 --> WQ
+```
+
+In the diagram above, readers A, B and C execute concurrently on threads from the shared pool and observe the graph state as it was when their query started. Writers X and Y are queued and executed one after the other, so concurrent writes to the same graph never interleave.
+
 ## Single Query Atomicity
 
 Every query that modifies the graph — using any combination of `CREATE`, `SET`, `DELETE`, or `MERGE` — is **atomic**. The entire query either succeeds completely or fails without applying any partial changes. There is no scenario where a failed query leaves the graph in an intermediate state.

--- a/operations/cluster.md
+++ b/operations/cluster.md
@@ -15,36 +15,36 @@ A FalkorDB cluster shards the keyspace across multiple master nodes using Redis 
 
 ```mermaid
 flowchart TB
-    Client(["Cluster-aware client<br/>(routes by graph name → slot)"])
+    Client(["Cluster-aware client<br/>(routes by graph name to slot)"])
 
-    subgraph Cluster["FalkorDB Cluster — 16,384 hash slots, gossiping masters"]
+    subgraph Cluster["FalkorDB Cluster: 16,384 hash slots, gossiping masters"]
         direction LR
 
-        subgraph S1["Shard 1 — slots 0–5460"]
+        subgraph S1["Shard 1: slots 0-5460"]
             direction TB
-            M1["Master — node1:6379<br/>────────────────<br/>social<br/>fraud<br/>catalog<br/>…"]
-            R1["Replica — node4:6382"]
+            M1["Master node1:6379<br/>────────────────<br/>social<br/>fraud<br/>catalog<br/>..."]
+            R1["Replica node4:6382"]
             M1 -. "async replication" .-> R1
         end
 
-        subgraph S2["Shard 2 — slots 5461–10922"]
+        subgraph S2["Shard 2: slots 5461-10922"]
             direction TB
-            M2["Master — node2:6380<br/>────────────────<br/>movies<br/>recommendations<br/>iot<br/>…"]
-            R2["Replica — node5:6383"]
+            M2["Master node2:6380<br/>────────────────<br/>movies<br/>recommendations<br/>iot<br/>..."]
+            R2["Replica node5:6383"]
             M2 -. "async replication" .-> R2
         end
 
-        subgraph S3["Shard 3 — slots 10923–16383"]
+        subgraph S3["Shard 3: slots 10923-16383"]
             direction TB
-            M3["Master — node3:6381<br/>────────────────<br/>knowledge<br/>supply_chain<br/>logs<br/>…"]
-            R3["Replica — node6:6384"]
+            M3["Master node3:6381<br/>────────────────<br/>knowledge<br/>supply_chain<br/>logs<br/>..."]
+            R3["Replica node6:6384"]
             M3 -. "async replication" .-> R3
         end
     end
 
-    Client == "GRAPH.QUERY social …" ==> M1
-    Client == "GRAPH.QUERY movies …" ==> M2
-    Client == "GRAPH.QUERY knowledge …" ==> M3
+    Client == "GRAPH.QUERY social ..." ==> M1
+    Client == "GRAPH.QUERY movies ..." ==> M2
+    Client == "GRAPH.QUERY knowledge ..." ==> M3
 ```
 
 The diagram shows the deployment built in this guide: three master shards laid out side by side, each owning a slice of the slot range and hosting many graph keys. The client sends each query to the shard that owns the graph being queried — `social` lives on shard 1, `movies` on shard 2, `knowledge` on shard 3 — while every master also asynchronously replicates its data to one replica for failover and read scaling.

--- a/operations/cluster.md
+++ b/operations/cluster.md
@@ -11,38 +11,51 @@ Setting up a FalkorDB cluster enables you to distribute your data across multipl
 
 ## Cluster Architecture Overview
 
-A FalkorDB cluster shards the keyspace across multiple master nodes using Redis Cluster's hash-slot mechanism (16,384 slots distributed across the masters). Each master can have one or more replicas that asynchronously copy its data, providing failover if the master becomes unavailable. Clients connect to any node and are transparently redirected to the master that owns the slot for the requested graph key.
+A FalkorDB cluster shards the keyspace across multiple master nodes using Redis Cluster's hash-slot mechanism (16,384 slots distributed across the masters). Each graph is a single Redis key, so it lives entirely on the shard whose slot range covers the hash of its name — different graphs typically land on different shards, and each shard ends up hosting many graphs. A cluster-aware client computes the slot for the target graph and routes the command directly to the master that owns it (or follows a `MOVED` redirect if it guesses wrong). Each master can have one or more replicas that asynchronously copy its data for failover and read scaling.
 
 ```mermaid
 flowchart TB
-    Client(["Client / Application"])
+    Client(["Cluster-aware client<br/>(routes by graph name → slot)"])
 
-    subgraph Cluster["FalkorDB Cluster (16,384 hash slots)"]
+    subgraph Cluster["FalkorDB Cluster — 16,384 hash slots, gossiping masters"]
         direction LR
-        subgraph S1["Shard 1<br/>slots 0–5460"]
+
+        subgraph S1["Shard 1 — slots 0–5460"]
+            direction TB
             M1["Master<br/>node1:6379"]
+            G1[("Graphs on shard 1<br/>• social<br/>• fraud<br/>• catalog<br/>• …")]
             R1["Replica<br/>node4:6382"]
+            M1 --- G1
             M1 -. "async replication" .-> R1
         end
-        subgraph S2["Shard 2<br/>slots 5461–10922"]
+
+        subgraph S2["Shard 2 — slots 5461–10922"]
+            direction TB
             M2["Master<br/>node2:6380"]
+            G2[("Graphs on shard 2<br/>• movies<br/>• recommendations<br/>• iot<br/>• …")]
             R2["Replica<br/>node5:6383"]
+            M2 --- G2
             M2 -. "async replication" .-> R2
         end
-        subgraph S3["Shard 3<br/>slots 10923–16383"]
+
+        subgraph S3["Shard 3 — slots 10923–16383"]
+            direction TB
             M3["Master<br/>node3:6381"]
+            G3[("Graphs on shard 3<br/>• knowledge<br/>• supply_chain<br/>• logs<br/>• …")]
             R3["Replica<br/>node6:6384"]
+            M3 --- G3
             M3 -. "async replication" .-> R3
         end
-        M1 <-- "gossip" --> M2
-        M2 <-- "gossip" --> M3
-        M1 <-- "gossip" --> M3
     end
 
-    Client -- "GRAPH.QUERY mygraph ..." --> M2
+    Client == "GRAPH.QUERY social …" ==> M1
+    Client == "GRAPH.QUERY movies …" ==> M2
+    Client == "GRAPH.QUERY knowledge …" ==> M3
 ```
 
-The diagram shows the deployment built in this guide: three master shards with one replica each, gossiping cluster state with one another while clients are routed to the master that owns the slot for the queried graph.
+The diagram shows the deployment built in this guide: three master shards laid out side by side, each owning a slice of the slot range and hosting many graph keys. The client sends each query to the shard that owns the graph being queried — `social` lives on shard 1, `movies` on shard 2, `knowledge` on shard 3 — while every master also asynchronously replicates its data to one replica for failover and read scaling.
+
+> **Note:** A single graph is *not* split across shards — all of its nodes and relationships live on one master. To co-locate two graphs on the same shard (for example, to use them in the same `MULTI`/`EXEC` block), use Redis [hash tags](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) in the graph names, e.g. `{tenant42}:users` and `{tenant42}:orders`.
 
 ## Prerequisites
 

--- a/operations/cluster.md
+++ b/operations/cluster.md
@@ -49,8 +49,6 @@ flowchart TB
 
 The diagram shows the deployment built in this guide: three master shards laid out side by side, each owning a slice of the slot range and hosting many graph keys. The client sends each query to the shard that owns the graph being queried — `social` lives on shard 1, `movies` on shard 2, `knowledge` on shard 3 — while every master also asynchronously replicates its data to one replica for failover and read scaling.
 
-> **Note:** A single graph is *not* split across shards — all of its nodes and relationships live on one master. To co-locate two graphs on the same shard (for example, to use them in the same `MULTI`/`EXEC` block), use Redis [hash tags](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) in the graph names, e.g. `{tenant42}:users` and `{tenant42}:orders`.
-
 ## Prerequisites
 
 Before you begin, ensure you have the following:

--- a/operations/cluster.md
+++ b/operations/cluster.md
@@ -22,28 +22,22 @@ flowchart TB
 
         subgraph S1["Shard 1 — slots 0–5460"]
             direction TB
-            M1["Master<br/>node1:6379"]
-            G1[("Graphs on shard 1<br/>• social<br/>• fraud<br/>• catalog<br/>• …")]
-            R1["Replica<br/>node4:6382"]
-            M1 --- G1
+            M1["Master — node1:6379<br/>────────────────<br/>social<br/>fraud<br/>catalog<br/>…"]
+            R1["Replica — node4:6382"]
             M1 -. "async replication" .-> R1
         end
 
         subgraph S2["Shard 2 — slots 5461–10922"]
             direction TB
-            M2["Master<br/>node2:6380"]
-            G2[("Graphs on shard 2<br/>• movies<br/>• recommendations<br/>• iot<br/>• …")]
-            R2["Replica<br/>node5:6383"]
-            M2 --- G2
+            M2["Master — node2:6380<br/>────────────────<br/>movies<br/>recommendations<br/>iot<br/>…"]
+            R2["Replica — node5:6383"]
             M2 -. "async replication" .-> R2
         end
 
         subgraph S3["Shard 3 — slots 10923–16383"]
             direction TB
-            M3["Master<br/>node3:6381"]
-            G3[("Graphs on shard 3<br/>• knowledge<br/>• supply_chain<br/>• logs<br/>• …")]
-            R3["Replica<br/>node6:6384"]
-            M3 --- G3
+            M3["Master — node3:6381<br/>────────────────<br/>knowledge<br/>supply_chain<br/>logs<br/>…"]
+            R3["Replica — node6:6384"]
             M3 -. "async replication" .-> R3
         end
     end

--- a/operations/cluster.md
+++ b/operations/cluster.md
@@ -9,6 +9,41 @@ parent: "Operations"
 
 Setting up a FalkorDB cluster enables you to distribute your data across multiple nodes, providing horizontal scalability and improved fault tolerance. This guide will walk you through the steps to configure a FalkorDB cluster with 3 masters and 1 replica for each, using Docker.
 
+## Cluster Architecture Overview
+
+A FalkorDB cluster shards the keyspace across multiple master nodes using Redis Cluster's hash-slot mechanism (16,384 slots distributed across the masters). Each master can have one or more replicas that asynchronously copy its data, providing failover if the master becomes unavailable. Clients connect to any node and are transparently redirected to the master that owns the slot for the requested graph key.
+
+```mermaid
+flowchart TB
+    Client(["Client / Application"])
+
+    subgraph Cluster["FalkorDB Cluster (16,384 hash slots)"]
+        direction LR
+        subgraph S1["Shard 1<br/>slots 0–5460"]
+            M1["Master<br/>node1:6379"]
+            R1["Replica<br/>node4:6382"]
+            M1 -. "async replication" .-> R1
+        end
+        subgraph S2["Shard 2<br/>slots 5461–10922"]
+            M2["Master<br/>node2:6380"]
+            R2["Replica<br/>node5:6383"]
+            M2 -. "async replication" .-> R2
+        end
+        subgraph S3["Shard 3<br/>slots 10923–16383"]
+            M3["Master<br/>node3:6381"]
+            R3["Replica<br/>node6:6384"]
+            M3 -. "async replication" .-> R3
+        end
+        M1 <-- "gossip" --> M2
+        M2 <-- "gossip" --> M3
+        M1 <-- "gossip" --> M3
+    end
+
+    Client -- "GRAPH.QUERY mygraph ..." --> M2
+```
+
+The diagram shows the deployment built in this guide: three master shards with one replica each, gossiping cluster state with one another while clients are routed to the master that owns the slot for the queried graph.
+
 ## Prerequisites
 
 Before you begin, ensure you have the following:

--- a/operations/replication.md
+++ b/operations/replication.md
@@ -12,6 +12,31 @@ redirect_from:
 
 FalkorDB supports advanced configurations to enable replication, ensuring that your data is available and synchronized across multiple instances. This guide will walk you through setting up FalkorDB in Docker with replication enabled, providing high availability and data redundancy.
 
+## Replication Architecture Overview
+
+FalkorDB replication follows a single-primary model: one master instance accepts all writes and asynchronously streams its changes to one or more replicas. Replicas serve read-only traffic, allowing read workloads to scale horizontally and providing a hot standby in case the master fails.
+
+```mermaid
+flowchart LR
+    W(["Write client"]) -- "GRAPH.QUERY" --> M
+    R1c(["Read client"]) -- "GRAPH.RO_QUERY" --> Rep1
+    R2c(["Read client"]) -- "GRAPH.RO_QUERY" --> Rep2
+
+    subgraph Primary["Primary"]
+        M["falkordb-master<br/>(read + write)"]
+    end
+
+    subgraph Replicas["Replicas (read-only)"]
+        Rep1["falkordb-replica1"]
+        Rep2["falkordb-replica2"]
+    end
+
+    M == "async replication stream" ==> Rep1
+    M == "async replication stream" ==> Rep2
+```
+
+Writes always flow through the master, while replicas mirror the master's state and absorb read traffic. Because replication is asynchronous, replicas may lag the master slightly under heavy write load — see the [Best Practices](#best-practices) section for tips on monitoring lag.
+
 ## Prerequisites
 
 Before you begin, ensure you have the following:

--- a/operations/replication.md
+++ b/operations/replication.md
@@ -19,8 +19,8 @@ FalkorDB replication follows a single-primary model: one master instance accepts
 ```mermaid
 flowchart LR
     W(["Write client"]) -- "GRAPH.QUERY" --> M
-    R1c(["Read client"]) -- "GRAPH.RO_QUERY" --> Rep1
-    R2c(["Read client"]) -- "GRAPH.RO_QUERY" --> Rep2
+    Rc(["Read client"]) -- "GRAPH.RO_QUERY" --> Rep1
+    Rc -- "GRAPH.RO_QUERY" --> Rep2
 
     subgraph Primary["Primary"]
         M["falkordb-master<br/>(read + write)"]


### PR DESCRIPTION
## Summary
Add high-level Mermaid architecture diagrams to the cluster, replication, and concurrency pages so readers can grasp the topology and concurrency model at a glance before walking through the step-by-step instructions.

## Changes
- **`_config.yml`** — enable Just-the-Docs built-in Mermaid rendering (`mermaid: version: "10.9.1"`) so ```mermaid fenced blocks render as SVG.
- **`operations/cluster.md`** — new *Cluster Architecture Overview* diagram showing 3 sharded masters with hash-slot ranges (0–5460, 5461–10922, 10923–16383), one replica per master, inter-master gossip, and client routing to the slot-owning master.
- **`operations/replication.md`** — new *Replication Architecture Overview* diagram showing the single-primary model: write client → master, async replication stream → replicas, read clients → replicas via `GRAPH.RO_QUERY`.
- **`design/concurrency.md`** — new *Concurrency Model at a Glance* diagram showing parallel readers on the `THREAD_COUNT` thread pool (snapshot view) vs. a serialized FIFO write queue per graph.

## Testing
Documentation-only change. Verified diagrams render with the Just-the-Docs Mermaid integration (it injects mermaid.js and renders ```mermaid fenced blocks). No build/test scripts in this repo beyond the spellchecker, which only inspects prose and ignores code blocks.

## Memory / Performance Impact
N/A — docs only.

## Related Issues
N/A