### PR TITLE
ci: replace built-in pages workflow with Node.js 24-compatible actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy Jekyll site to Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary
Replace the GitHub-managed `pages-build-deployment` workflow with a custom Jekyll deploy workflow that uses Node.js 24-compatible action versions, eliminating the Node.js 20 deprecation warning.

## Changes
- Add `.github/workflows/pages.yml` — custom GitHub Pages deploy workflow
- All actions pinned to full commit SHAs (security best practice):
  - `actions/checkout@v6.0.2` — Node.js 24 runtime (was `@v4` / Node.js 20)
  - `actions/configure-pages@v6.0.0`
  - `actions/jekyll-build-pages@v1.0.13` (unchanged)
  - `actions/upload-pages-artifact@v5.0.0` (replaces `upload-artifact@v4`)
  - `actions/deploy-pages@v5.0.0`

## Testing
The new workflow will trigger on merge to `main`. It replicates the exact steps of the built-in `pages-build-deployment` workflow using up-to-date actions.

> **Note:** After merging, verify in **Settings → Pages** that the deployment source is the new custom workflow. The built-in workflow may need to be disabled from there if both run simultaneously.

## Memory / Performance Impact
N/A

## Related Issues
Fixes Node.js 20 deprecation warning:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: actions/checkout@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.