### PR TITLE
fix(security): add SRI integrity hashes to highlight.js CDN resources

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,8 +1,8 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/atom-one-dark.min.css"
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/atom-one-dark.min.css"
   integrity="sha512-Jk4AqjWsdSzSWCSuQTfYRIF84Rq/eV0G2+tu07byYwHcbTGfdmLrHjUSwvzp5HvbiqK4ibmNwdcG49Y5RGYPTg=="
   crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"
-  integrity="sha512-6yoqbrcLAHDWAdQmiRlHG4+m0g/CT/V9AGyxabG8j7Jk8j3r3K6due7oqpiRMZqcYe9WM2gPcaNNxnl2ux+3tA=="
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"
+  integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw=="
   crossorigin="anonymous"></script>
 <script>hljs.highlightAll();</script>
 

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,5 +1,9 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/atom-one-dark.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/atom-one-dark.min.css"
+  integrity="sha512-Jk4AqjWsdSzSWCSuQTfYRIF84Rq/eV0G2+tu07byYwHcbTGfdmLrHjUSwvzp5HvbiqK4ibmNwdcG49Y5RGYPTg=="
+  crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js"
+  integrity="sha512-6yoqbrcLAHDWAdQmiRlHG4+m0g/CT/V9AGyxabG8j7Jk8j3r3K6due7oqpiRMZqcYe9WM2gPcaNNxnl2ux+3tA=="
+  crossorigin="anonymous"></script>
 <script>hljs.highlightAll();</script>
 
 {% if site.gtm_tracking != nil %}


### PR DESCRIPTION
## Summary

Fixes CodeQL security alert [#13](https://github.com/FalkorDB/docs/security/code-scanning/13): **CWE-830 — Inclusion of functionality from an untrusted source**.

Both the highlight.js script and atom-one-dark stylesheet were loaded from \`cdnjs.cloudflare.com\` without Subresource Integrity (SRI) checks, meaning a compromised CDN could serve malicious code to all docs visitors.

## Changes

- Added \`integrity="sha512-…"\` and \`crossorigin="anonymous"\` to the \`<link>\` (CSS) and \`<script>\` (JS) tags in \`_includes/head_custom.html\`.
- SRI hashes sourced directly from the cdnjs API for highlight.js 11.11.1.

## Testing

SRI hashes verified against cdnjs API response for highlight.js 11.11.1. The browser will reject the resource if the hash doesn't match, preventing code injection even if the CDN is compromised.

## Memory / Performance Impact

N/A — no functional change, no additional resources loaded.

## Related Issues

Closes https://github.com/FalkorDB/docs/security/code-scanning/13