### PR TITLE
fix(nav): make logo link to docs home; move FalkorDB.com to aux_links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ tagline: "Graph Database for GraphRAG, Cypher & Knowledge Graphs"
 description: "Official FalkorDB documentation — the high-performance graph database for GraphRAG, Cypher queries, and knowledge graphs powering accurate GenAI applications."
 url: "https://docs.falkordb.com"
 logo: "/images/falkor-logo.png"
-logo_link: "https://www.falkordb.com"
+logo_link: "/"
 favicon_ico: "/images/favicon.ico"
 gtm_tracking: GTM-MBWB627H
 
@@ -16,6 +16,8 @@ search_enabled: true
 color_scheme: falkordb-dark
 
 aux_links:
+  "FalkorDB.com":
+    - "https://www.falkordb.com"
   "Docs Repository":
     - "https://github.com/falkordb/docs"
   "FalkorDB Repository":


### PR DESCRIPTION
## Summary

Follow-up to #443: the AEO title fix used `nav_exclude: true` on `index.md` to avoid the generic "Home | FalkorDB Docs" title, but the sidebar logo was linking to `www.falkordb.com` (marketing site), leaving no navigation path back to the docs homepage.

## Changes

- `logo_link: "/"` — logo now links to the docs root (standard just-the-docs pattern; the logo **is** the home link in this theme).
- Added `"FalkorDB.com": https://www.falkordb.com` to `aux_links` so the marketing site remains easily reachable from the top-right corner of every page.

## Testing

Spellcheck passes. GitHub Pages will validate the Jekyll build on merge.

## Memory / Performance Impact

N/A — config-only change.

## Related Issues

Follow-up to #443.