### PR TITLE
docs(homepage): add Getting Started guide CTA after Docker quickstart

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,6 +60,8 @@ docker run -p 6379:6379 -p 3000:3000 -it --rm falkordb/falkordb:latest
 
 Once loaded, you can interact with FalkorDB using any of the supported [client libraries](/getting-started/clients)
 
+> **📖 New to FalkorDB?** Follow the step-by-step [Getting Started guide](/getting-started) for a complete walkthrough — from setup to modeling, loading, and querying your first graph.
+
 Here we'll use [FalkorDB Python client](https://pypi.org/project/FalkorDB/) to create a small graph representing a subset of motorcycle riders and teams taking part in the MotoGP league, once created we'll start querying our data.
 
 


### PR DESCRIPTION
## Summary
Add a prominent call-to-action linking to the Getting Started guide right after the Docker quickstart section on the homepage.

## Changes
- Added a `📖 New to FalkorDB?` callout box between the Docker quickstart and the MotoGP code example on `index.md`
- Links directly to `/getting-started` for the step-by-step walkthrough

## Testing
- Visual inspection of markdown rendering
- Link target `/getting-started` exists and resolves correctly

## Memory / Performance Impact
N/A — documentation only

## Related Issues
Addresses audit item P2.3 (Audit-Report.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "New to FalkorDB?" callout on the documentation homepage directing first-time users to the Getting Started guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->