### PR TITLE
docs(getting-started): add FalkorDB Browser link to Explore Further

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -378,7 +378,7 @@ for record in result.data.by_ref() {
 Congratulations! 🎉 You have successfully modeled, loaded, and queried a social network graph with FalkorDB.
 
 Next, dive deeper into FalkorDB's powerful features:
-- [FalkorDB Browser](/browser) — Explore your graph visually at [http://localhost:3000](http://localhost:3000)
+- [FalkorDB Browser](/browser) — Explore your graph visually
 - [Advanced Cypher](/cypher)
 - [Database Operations](/operations)
 - [GenAI Tools](/genai-tools)

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -378,6 +378,7 @@ for record in result.data.by_ref() {
 Congratulations! 🎉 You have successfully modeled, loaded, and queried a social network graph with FalkorDB.
 
 Next, dive deeper into FalkorDB's powerful features:
+- [FalkorDB Browser](/browser) — Explore your graph visually at [http://localhost:3000](http://localhost:3000)
 - [Advanced Cypher](/cypher)
 - [Database Operations](/operations)
 - [GenAI Tools](/genai-tools)


### PR DESCRIPTION
## Summary
Add a link to FalkorDB Browser in the Getting Started guide's "Explore Further" section so users know about the visual interface at localhost:3000.

## Changes
- Added `FalkorDB Browser` as the first item in the Explore Further list in `getting-started/index.md`
- Includes a direct link to `http://localhost:3000` for quick access

## Testing
- Visual inspection of markdown rendering
- Link targets exist: `/browser` and `http://localhost:3000`

## Memory / Performance Impact
N/A — documentation only

## Related Issues
Addresses audit item P2.4 (Audit-Report.md)