### PR TITLE
docs: add cross-links to and from datatypes page

### DIFF
--- a/cypher/index.md
+++ b/cypher/index.md
@@ -12,6 +12,8 @@ FalkorDB supports the [OpenCypher](https://www.opencypher.org/) query language w
 
 This section provides a complete reference for all supported Cypher clauses, functions, procedures, and indexing capabilities.
 
+> **See also:** [Data Types](/datatypes) — Reference for all node, relationship, scalar, temporal, and collection types used in Cypher queries.
+
 ## Comments
 
 FalkorDB Cypher supports two comment styles that can be placed anywhere whitespace is allowed:

--- a/datatypes.md
+++ b/datatypes.md
@@ -307,3 +307,12 @@ RETURN u {.name, follower_count: count} AS user"
 2) 1) 1) "{name: Jeff, follower_count: 12}"
    2) 1) "{name: Roi, follower_count: 18}"
 ```
+
+---
+
+## Next Steps
+
+- [Getting Started](/getting-started) — Build and query your first graph
+- [Cypher Language](/cypher) — Learn the query language for working with these data types
+- [Indexing](/cypher/indexing) — Create indexes on properties to speed up queries
+- [Commands](/commands) — Full command reference for GRAPH.QUERY and more

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -379,6 +379,7 @@ Congratulations! 🎉 You have successfully modeled, loaded, and queried a socia
 
 Next, dive deeper into FalkorDB's powerful features:
 - [Advanced Cypher](/cypher)
+- [Data Types](/datatypes) — Nodes, relationships, scalars, temporal types, and collections
 - [Database Operations](/operations)
 - [GenAI Tools](/genai-tools)
 - [Agentic Memory](/agentic-memory)


### PR DESCRIPTION
## Summary
Make the Data Types page discoverable by linking to it from the Getting Started guide and Cypher reference, and add a "Next Steps" section to the datatypes page itself.

## Changes
- `datatypes.md`: Added "Next Steps" section with links to Getting Started, Cypher, Indexing, and Commands
- `getting-started/index.md`: Added Data Types link in the Explore Further section
- `cypher/index.md`: Added "See also" callout linking to Data Types reference

## Testing
- Visual inspection of markdown rendering
- All link targets verified to exist

## Memory / Performance Impact
N/A — documentation only

## Related Issues
Addresses audit item P2.10 (Audit-Report.md)