### PR TITLE
docs(cloud): consolidate pricing table into cloud index page

### DIFF
--- a/cloud/enterprise-tier.md
+++ b/cloud/enterprise-tier.md
@@ -13,25 +13,7 @@ FalkorDB's **Enterprise Tier** is designed for the most demanding workloads, off
 
 The Enterprise Tier is fully optimized for mission-critical applications, providing the highest levels of security, availability, and dedicated operational support. Deployment configurations are tailored to your specific infrastructure, scale, and compliance requirements.
 
-## FalkorDB Pricing Plans Comparison
-
-| Feature | FREE | STARTUP | PRO | ENTERPRISE |
-| :--- | :---: | :---: | :---: | :---: |
-| **Monthly Cost (from)** | **Free** | **$73** | **$350** | **Custom** |
-| Multi-Graph / Multi-Tenancy | ✓ | ✓ | ✓ | **🟢** |
-| Graph Access Control | ✓ | ✓ | ✓ | **🟢** |
-| **TLS** | ✗ | ✓ | ✓ | **🟢** |
-| **VPC** | ✗ | ✗ | ✗ | **🟢** |
-| Cluster Deployment | ✗ | ✗ | ✓ | **🟢** |
-| High Availability | ✗ | ✗ | ✓ | **🟢** |
-| Multi-zone Deployment | ✗ | ✗ | ✓ | **🟢** |
-| Scalability | ✗ | ✗ | ✓ | **🟢** |
-| Continuous Persistence | ✗ | ✗ | ✓ | **🟢** |
-| **Automated Backups** | ✗ | Every 12 Hours | Every 12 Hours | **Every Hour** |
-| **Advanced Monitoring** | ✗ | ✗ | ✗ | **🟢** |
-| **Support** | Community | Community | 24/7 | **Dedicated** |
-| **Dedicated Account Manager** | ✗ | ✗ | ✗ | **🟢** |
-| **Cloud Providers** | AWS, GCP, Azure | AWS, GCP, Azure | AWS, GCP, Azure | **AWS, GCP, Azure** |
+> **📊 Compare all plans:** See the [full pricing comparison](/cloud#pricing-plans-comparison) on the Cloud overview page.
 
 ## Terms
 ### Consultation and Pricing

--- a/cloud/free-tier.md
+++ b/cloud/free-tier.md
@@ -12,26 +12,7 @@ FalkorDB's free cloud tier gives you instant access to a graph database with mul
 
 The free tier provides everything you need to explore FalkorDB and build initial prototypes. When your application grows and requires TLS security, VPC networking, high availability, automated backups, or dedicated support, you can upgrade to a paid plan that includes these enterprise features.
 
-## FalkorDB Pricing Plans Comparison
-
-| Feature | FREE | STARTUP | PRO | ENTERPRISE |
-| :--- | :---: | :---: | :---: | :---: |
-| **Monthly Cost (from)** | **Free** | **$73** | **$350** | **Custom** |
-| Multi-Graph / Multi-Tenancy | **✓** | **✓** | **✓** | **✓** |
-| Graph Access Control | **✓** | **✓** | **✓** | **✓** |
-| TLS | ✗ | **✓** | **✓** | **✓** |
-| VPC | ✗ | ✗ | ✗ | **✓** |
-| Cluster Deployment | ✗ | ✗ | **✓** | **✓** |
-| High Availability | ✗ | ✗ | **✓** | **✓** |
-| Multi-zone Deployment | ✗ | ✗ | **✓** | **✓** |
-| Scalability | ✗ | ✗ | **✓** | **✓** |
-| Continuous Persistence | ✗ | ✗ | **✓** | **✓** |
-| Automated Backups | ✗ | Every 12 Hours | Every 12 Hours | Every Hour |
-| Advanced Monitoring | ✗ | ✗ | ✗ | **✓** |
-| **Support** | Community | Community | 24/7 | Dedicated |
-| Dedicated Account Manager | ✗ | ✗ | ✗ | **✓** |
-| **Cloud Providers** | AWS, GCP | AWS, GCP | AWS, GCP | AWS, GCP, Azure |
-| **Call-to-Action** | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Contact Us](mailto:info@falkordb.com) |
+> **📊 Compare all plans:** See the [full pricing comparison](/cloud#pricing-plans-comparison) on the Cloud overview page.
 
 ## Terms
 > ⚠️ Free instances that aren't utilized for 1 day will be stopped, and deleted after 7 days.

--- a/cloud/index.md
+++ b/cloud/index.md
@@ -27,6 +27,29 @@ Get started with FalkorDB's cloud offering. The platform provides several enterp
 
 ---
 
+## Pricing Plans Comparison
+
+| Feature | FREE | STARTUP | PRO | ENTERPRISE |
+| :--- | :---: | :---: | :---: | :---: |
+| **Monthly Cost (from)** | **Free** | **$73** | **$350** | **Custom** |
+| Multi-Graph / Multi-Tenancy | ✓ | ✓ | ✓ | ✓ |
+| Graph Access Control | ✓ | ✓ | ✓ | ✓ |
+| TLS | ✗ | ✓ | ✓ | ✓ |
+| VPC | ✗ | ✗ | ✗ | ✓ |
+| Cluster Deployment | ✗ | ✗ | ✓ | ✓ |
+| High Availability | ✗ | ✗ | ✓ | ✓ |
+| Multi-zone Deployment | ✗ | ✗ | ✓ | ✓ |
+| Scalability | ✗ | ✗ | ✓ | ✓ |
+| Continuous Persistence | ✗ | ✗ | ✓ | ✓ |
+| Automated Backups | ✗ | Every 12 Hours | Every 12 Hours | Every Hour |
+| Advanced Monitoring | ✗ | ✗ | ✗ | ✓ |
+| **Support** | Community | Community | 24/7 | Dedicated |
+| Dedicated Account Manager | ✗ | ✗ | ✗ | ✓ |
+| **Cloud Providers** | AWS, GCP | AWS, GCP | AWS, GCP | AWS, GCP, Azure (BYOC) |
+| **Call-to-Action** | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Contact Us](mailto:info@falkordb.com) |
+
+---
+
 ### Billing & Setup
 ℹ️ Prior to subscribing to any of FalkorDB's paid cloud tiers, please set up your billing information here:
 > Adding your billing information is an easy, 2-step process:

--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -13,26 +13,7 @@ FalkorDB's **Pro Tier** is your solution for high-performance, production-ready 
 
 The Pro Tier provides a robust environment to scale your application with confidence. When your needs extend to features like VPC Peering, Advanced Monitoring, or a Dedicated Account Manager, you can easily upgrade to the Enterprise plan.
 
-## FalkorDB Pricing Plans Comparison
-
-| Feature | FREE | STARTUP | PRO | ENTERPRISE |
-| :--- | :---: | :---: | :---: | :---: |
-| **Monthly Cost (from)** | **Free** | **$73** | **$350** | **Custom** |
-| Multi-Graph / Multi-Tenancy | ✓ | ✓ | **🟢** | ✓ |
-| Graph Access Control | ✓ | ✓ | **🟢** | ✓ |
-| **TLS** | ✗ | ✓ | **🟢** | ✓ |
-| VPC | ✗ | ✗ | **🔴** | ✓ |
-| Cluster Deployment | ✗ | ✗ | **🟢** | ✓ |
-| High Availability | ✗ | ✗ | **🟢** | ✓ |
-| Multi-zone Deployment | ✗ | ✗ | **🟢** | ✓ |
-| Scalability | ✗ | ✗ | **🟢** | ✓ |
-| Continuous Persistence | ✗ | ✗ | **🟢** | ✓ |
-| **Automated Backups** | ✗ | Every 12 Hours | **Every 12 Hours** | Every Hour |
-| Advanced Monitoring | ✗ | ✗ | **🔴** | ✓ |
-| **Support** | Community | Community | **24/7** | Dedicated |
-| Dedicated Account Manager | ✗ | ✗ | **🔴** | ✓ |
-| **Cloud Providers** | AWS, GCP | AWS, GCP | **AWS, GCP** | AWS, GCP, Azure (BYOC) |
-| **Get started** | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Contact Us](mailto:info@falkordb.com) |
+> **📊 Compare all plans:** See the [full pricing comparison](/cloud#pricing-plans-comparison) on the Cloud overview page.
 
 ## Terms
 ### Pricing Calculation

--- a/cloud/startup-tier.md
+++ b/cloud/startup-tier.md
@@ -13,26 +13,7 @@ FalkorDB's **Startup Tier** gives you instant access to a production-ready graph
 
 The Startup Tier includes essential features like **TLS** and **Automated Backups (Every 12 Hours)**, making it a robust, secure choice for your first production workload. When your application requires High Availability, dedicated support, or advanced enterprise features like VPC networking, you can easily upgrade to a Pro or Enterprise plan.
 
-## FalkorDB Pricing Plans Comparison
-
-| Feature | FREE | STARTUP | PRO | ENTERPRISE |
-| :--- | :---: | :---: | :---: | :---: |
-| **Monthly Cost (from)** | **Free** | **$73** | **$350** | **Custom** |
-| Multi-Graph / Multi-Tenancy | ✓ | **🟢** | ✓ | ✓ |
-| Graph Access Control | ✓ | **🟢** | ✓ | ✓ |
-| **TLS** | ✗ | **🟢** | ✓ | ✓ |
-| VPC | ✗ | **🔴** | ✗ | ✓ |
-| Cluster Deployment | ✗ | **🔴** | ✓ | ✓ |
-| High Availability | ✗ | **🔴** | ✓ | ✓ |
-| Multi-zone Deployment | ✗ | **🔴** | ✓ | ✓ |
-| Scalability | ✗ | **🔴** | ✓ | ✓ |
-| Continuous Persistence | ✗ | **🔴** | ✓ | ✓ |
-| **Automated Backups** | ✗ | **Every 12 Hours** | Every 12 Hours | Every Hour |
-| Advanced Monitoring | ✗ | **🔴** | ✗ | ✓ |
-| **Support** | Community | **Community** | 24/7 | Dedicated |
-| Dedicated Account Manager | ✗ | **🔴** | ✗ | ✓ |
-| **Cloud Providers** | AWS, GCP | **AWS, GCP** | AWS, GCP | AWS, GCP, Azure (BYOC) |
-| **Call-to-Action** | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Sign up](https://app.falkordb.cloud/signup) | [Contact Us](mailto:info@falkordb.com) |
+> **📊 Compare all plans:** See the [full pricing comparison](/cloud#pricing-plans-comparison) on the Cloud overview page.
 
 ## Terms
 ### Pricing Calculation


### PR DESCRIPTION
## Summary
Move the 4-tier pricing comparison table to `cloud/index.md` as the single source of truth, eliminating 4× duplication across tier pages.

## Changes
- `cloud/index.md`: Added canonical pricing comparison table
- `cloud/free-tier.md`: Removed duplicate table, added link to central table
- `cloud/startup-tier.md`: Removed duplicate table, added link to central table
- `cloud/pro-tier.md`: Removed duplicate table, added link to central table
- `cloud/enterprise-tier.md`: Removed duplicate table, added link to central table

## Why
Previously, when prices changed all four tier pages had to be updated identically. The tables had already drifted — different emoji styles (✓ vs 🟢), inconsistent cloud provider claims, and different CTA labels.

## Testing
- Verified all tier pages link to `/cloud#pricing-plans-comparison`
- Tier-specific pricing details (instance sizes, calculations) remain on individual pages

## Memory / Performance Impact
N/A — documentation only

## Related Issues
Addresses audit item P2.5 (Audit-Report.md)

> **Note:** This PR may conflict with #454 (cloud provider alignment) since both touch cloud tier files. Merge one first, then rebase the other.