### PR TITLE
fix(workflow): read GRAPHRAG_UI_URL from secrets, not vars

### DIFF
--- a/.github/workflows/update-graph.yml
+++ b/.github/workflows/update-graph.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
     env:
       GRAPH_ID: docs_benchmark
-      GRAPHRAG_UI_URL: ${{ vars.GRAPHRAG_UI_URL }}
+      GRAPHRAG_UI_URL: ${{ secrets.GRAPHRAG_UI_URL }}
     steps:
       - name: Checkout docs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
First real merge to main hit `curl: (3) URL rejected: No host part in the URL` because the workflow reads `${{ vars.GRAPHRAG_UI_URL }}` but the repo has the URL configured as a **secret**, not a **variable**, so the env var resolved to an empty string.

A public URL doesn't strictly need to live in the secret namespace (variables are fine and visible in the UI for debugging), but matching the workflow to where the value already exists is the least-disruptive fix.

## Change
One line in `.github/workflows/update-graph.yml`:

```diff
-      GRAPHRAG_UI_URL: ${{ vars.GRAPHRAG_UI_URL }}
+      GRAPHRAG_UI_URL: ${{ secrets.GRAPHRAG_UI_URL }}
```

## After merge
The next `.md` push to main should run the workflow successfully end-to-end. Result will mirror the wet-run done earlier today (`docs_v6_*` pending → smoke test → atomic alias flip on `:Graph` node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)