### PR TITLE
docs(cloud): add hourly cost column to paid-tier pricing tables

### DIFF
--- a/cloud/enterprise-tier.md
+++ b/cloud/enterprise-tier.md
@@ -35,7 +35,7 @@ The Enterprise Tier is fully optimized for mission-critical applications, provid
 
 ## Terms
 ### Consultation and Pricing
-> The Enterprise Tier is customized to your specific needs, leveraging dedicated resources, tailored support SLAs, and private deployment options. Pricing is calculated based on the custom configuration of cores, memory, and additional enterprise components.
+> The Enterprise Tier is customized to your specific needs, leveraging dedicated resources, tailored support SLAs, and private deployment options. Pricing is calculated on a per-hour basis (Core/Hour and Memory GB/Hour) based on the custom configuration of cores, memory, and additional enterprise components.
 >
 > **For precise pricing, deployment details, and a dedicated consultation:**
 > **[Contact our Sales Team](https://www.falkordb.com/get-a-demo/)**

--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -40,44 +40,46 @@ The Pro Tier provides a robust environment to scale your application with confid
 
 ## Standalone
 
-| Instance Type | Cores | Memory (GB) | Max Graph Dataset (GB) | Monthly Cost |
-| :--- | :---: | :---: | :---: | ---: |
-| E2-medium | 1 | 4 | 2 | $175.20 |
-| t2.medium | 2 | 4 | 2 | $321.20 |
-| E2-standard-2 / m6i.large (Starting Instance) | 2 | 8 | 6 | $350.40 |
-| E2-standard-4 / m6i.xlarge | 4 | 16 | 12 | $700.80 |
-| E2-standard-8 / m6i.2xlarge | 8 | 32 | 24 | $1,401.60 |
-| E2-highmem-2 / r6i.large | 2 | 16 | 12 | $408.80 |
-| E2-highmem-4 / r6i.xlarge | 4 | 32 | 24 | $817.60 |
-| E2-highmem-8 / r6i.2xlarge | 8 | 64 | 48 | $1,635.20 |
-| m6i.4xlarge | 16 | 64 | 48 | $2,803.20 |
-| m6i.8xlarge | 32 | 128 | 96 | $5,606.40 |
-| r6i.4xlarge | 16 | 128 | 96 | $3,270.40 |
-| E2-custom-4-8192 / c6i.xlarge | 4 | 8 | 6 | $642.40 |
-| E2-custom-8-16384 / c6i.2xlarge | 8 | 16 | 12 | $1,284.80 |
-| E2-custom-16-32768 / c6i.4xlarge | 16 | 32 | 24 | $2,569.60 |
-| E2-custom-32-65536 / c6i.8xlarge | 32 | 64 | 48 | $5,139.20 |
+| Instance Type | Cores | Memory (GB) | Max Graph Dataset (GB) | Hourly Cost | Monthly Cost |
+| :--- | :---: | :---: | :---: | ---: | ---: |
+| E2-medium | 1 | 4 | 2 | $0.240/hr | $175.20 |
+| t2.medium | 2 | 4 | 2 | $0.440/hr | $321.20 |
+| E2-standard-2 / m6i.large (Starting Instance) | 2 | 8 | 6 | $0.480/hr | $350.40 |
+| E2-standard-4 / m6i.xlarge | 4 | 16 | 12 | $0.960/hr | $700.80 |
+| E2-standard-8 / m6i.2xlarge | 8 | 32 | 24 | $1.920/hr | $1,401.60 |
+| E2-highmem-2 / r6i.large | 2 | 16 | 12 | $0.560/hr | $408.80 |
+| E2-highmem-4 / r6i.xlarge | 4 | 32 | 24 | $1.120/hr | $817.60 |
+| E2-highmem-8 / r6i.2xlarge | 8 | 64 | 48 | $2.240/hr | $1,635.20 |
+| m6i.4xlarge | 16 | 64 | 48 | $3.840/hr | $2,803.20 |
+| m6i.8xlarge | 32 | 128 | 96 | $7.680/hr | $5,606.40 |
+| r6i.4xlarge | 16 | 128 | 96 | $4.480/hr | $3,270.40 |
+| E2-custom-4-8192 / c6i.xlarge | 4 | 8 | 6 | $0.880/hr | $642.40 |
+| E2-custom-8-16384 / c6i.2xlarge | 8 | 16 | 12 | $1.760/hr | $1,284.80 |
+| E2-custom-16-32768 / c6i.4xlarge | 16 | 32 | 24 | $3.520/hr | $2,569.60 |
+| E2-custom-32-65536 / c6i.8xlarge | 32 | 64 | 48 | $7.040/hr | $5,139.20 |
+
+> Monthly Cost = Hourly Cost × 730 hours/month.
 
 ## Replicated (High Availability, Master (x1), Replica (x1))
 
 
-| Instances Type                                 | Cores | Memory (GB) | Max Graph Dataset (GB) | Monthly Cost |
-| :--------------------------------------------- | :---: | :---------: | :--------------------: | -----------: |
-| E2-medium                                      |   1   |      4      |           2            |     \$657.00 |
-| t2.medium                                      |   2   |      4      |           2            |     \$949.00 |
-| E2-standard-2 / m6i.large (Starting Instance)  |   2   |      8      |           6            |   \$1,007.40 |
-| E2-standard-4 / m6i.xlarge                     |   4   |     16      |           12           |   \$1,708.20 |
-| E2-standard-8 / m6i.2xlarge                    |   8   |     32      |           24           |   \$3,109.80 |
-| E2-highmem-2 / r6i.large                       |   2   |     16      |           12           |   \$1,124.20 |
-| E2-highmem-4 / r6i.xlarge                      |   4   |     32      |           24           |   \$1,941.80 |
-| E2-highmem-8 / r6i.2xlarge                     |   8   |     64      |           48           |   \$3,577.00 |
-| m6i.4xlarge                                    |  16   |     64      |           48           |   \$5,913.00 |
-| m6i.8xlarge                                    |  32   |    128      |           96           |  \$11,519.40 |
-| r6i.4xlarge                                    |  16   |    128      |           96           |   \$6,847.40 |
-| E2-custom-4-8192 / c6i.xlarge                  |   4   |      8      |           6            |   \$1,591.40 |
-| E2-custom-8-16384 / c6i.2xlarge                |   8   |     16      |           12           |   \$2,876.20 |
-| E2-custom-16-32768 / c6i.4xlarge               |  16   |     32      |           24           |   \$5,445.80 |
-| E2-custom-32-65536 / c6i.8xlarge               |  32   |     64      |           48           |  \$10,585.00 |
+| Instances Type                                 | Cores | Memory (GB) | Max Graph Dataset (GB) | Hourly Cost  | Monthly Cost |
+| :--------------------------------------------- | :---: | :---------: | :--------------------: | -----------: | -----------: |
+| E2-medium                                      |   1   |      4      |           2            |   \$0.900/hr |     \$657.00 |
+| t2.medium                                      |   2   |      4      |           2            |   \$1.300/hr |     \$949.00 |
+| E2-standard-2 / m6i.large (Starting Instance)  |   2   |      8      |           6            |   \$1.380/hr |   \$1,007.40 |
+| E2-standard-4 / m6i.xlarge                     |   4   |     16      |           12           |   \$2.340/hr |   \$1,708.20 |
+| E2-standard-8 / m6i.2xlarge                    |   8   |     32      |           24           |   \$4.260/hr |   \$3,109.80 |
+| E2-highmem-2 / r6i.large                       |   2   |     16      |           12           |   \$1.540/hr |   \$1,124.20 |
+| E2-highmem-4 / r6i.xlarge                      |   4   |     32      |           24           |   \$2.660/hr |   \$1,941.80 |
+| E2-highmem-8 / r6i.2xlarge                     |   8   |     64      |           48           |   \$4.900/hr |   \$3,577.00 |
+| m6i.4xlarge                                    |  16   |     64      |           48           |   \$8.100/hr |   \$5,913.00 |
+| m6i.8xlarge                                    |  32   |    128      |           96           |  \$15.780/hr |  \$11,519.40 |
+| r6i.4xlarge                                    |  16   |    128      |           96           |   \$9.380/hr |   \$6,847.40 |
+| E2-custom-4-8192 / c6i.xlarge                  |   4   |      8      |           6            |   \$2.180/hr |   \$1,591.40 |
+| E2-custom-8-16384 / c6i.2xlarge                |   8   |     16      |           12           |   \$3.940/hr |   \$2,876.20 |
+| E2-custom-16-32768 / c6i.4xlarge               |  16   |     32      |           24           |   \$7.460/hr |   \$5,445.80 |
+| E2-custom-32-65536 / c6i.8xlarge               |  32   |     64      |           48           |  \$14.500/hr |  \$10,585.00 |
 
 > Note: In the Replicated table, **Cores** and **Memory (GB)** are per instance. **Max Graph Dataset (GB)** is calculated as 2 GB for 4 GB containers and 75% of memory for containers larger than 4 GB. We charge an additional 2 cores and 2 GB for replication and cluster since they require an extra component (sentinel for replication and rebalancer for cluster).
 

--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -63,7 +63,7 @@ The Pro Tier provides a robust environment to scale your application with confid
 ## Replicated (High Availability, Master (x1), Replica (x1))
 
 
-| Instances Type                                 | Cores | Memory (GB) | Max Graph Dataset (GB) | Hourly Cost  | Monthly Cost |
+| Instance Type                                  | Cores | Memory (GB) | Max Graph Dataset (GB) | Hourly Cost  | Monthly Cost |
 | :--------------------------------------------- | :---: | :---------: | :--------------------: | -----------: | -----------: |
 | E2-medium                                      |   1   |      4      |           2            |   \$0.900/hr |     \$657.00 |
 | t2.medium                                      |   2   |      4      |           2            |   \$1.300/hr |     \$949.00 |

--- a/cloud/startup-tier.md
+++ b/cloud/startup-tier.md
@@ -40,10 +40,12 @@ The Startup Tier includes essential features like **TLS** and **Automated Backup
 >
 > The table below shows approximate monthly costs for different instance sizes (based on 730 hours/month), along with max graph dataset size (75% of RAM):
 >
-> | Instance Size (RAM) | Max Graph Dataset (GB) | Monthly Cost |
-> | :--- | ---: | ---: |
-> | 1 GB | 0.75 | $73/month* |
-> | 2 GB | 1.5 | $146/month* |
+> | Instance Size (RAM) | Max Graph Dataset (GB) | Hourly Cost | Monthly Cost |
+> | :--- | ---: | ---: | ---: |
+> | 1 GB | 0.75 | $0.100/hr | $73/month* |
+> | 2 GB | 1.5 | $0.200/hr | $146/month* |
+>
+> Monthly Cost = Hourly Cost × 730 hours/month.
 >
 > You can estimate your monthly costs by multiplying your instance's memory allocation (in GB) by **$73**.
 >


### PR DESCRIPTION
## Summary
The Pro and Startup tier pages list a per-hour rate in prose (\$0.200/Core/Hour, \$0.01/Memory GB/Hour, \$0.100/Memory GB/Hour for Startup) but the instance tables only show monthly totals. This PR adds an **Hourly Cost** column to each instance table so users can:
- See the unit billing rate at a glance (matches how usage-based billing actually works).
- Estimate cost for non-24x7 workloads, dev/test, and autoscaling scenarios.
- Avoid having to mentally divide monthly numbers by 730 to reconcile with the prose.

## Changes
- `cloud/startup-tier.md`: add **Hourly Cost** column to the instance pricing table; add a footnote that `Monthly Cost = Hourly Cost x 730 hours/month`.
- `cloud/pro-tier.md`: add **Hourly Cost** column to both the **Standalone** and **Replicated (HA)** instance pricing tables; add the same footnote under Standalone.
- `cloud/enterprise-tier.md`: clarify that Enterprise custom pricing is also calculated on a per-hour basis (Core/Hour + Memory GB/Hour), to keep terminology consistent with the other paid tiers.

All hourly figures were derived from the published unit rates and verified against the existing monthly totals (e.g., Pro standalone E2-standard-2 = 2 cores x \$0.200 + 8 GB x \$0.01 = \$0.480/hr x 730 = \$350.40/month). Replicated hourly values are existing monthly / 730.

## Testing
N/A - documentation-only change. No code, build, or test impact.

## Memory / Performance Impact
N/A.

## Related Issues
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pricing documentation across all service tiers to include hourly cost rates alongside monthly pricing.
  * Added transparent pricing formula showing the monthly-to-hourly conversion (730 hours/month) for clarity.
  * Clarified per-hour pricing calculation methodology for all tier levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/docs/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->