### PR TITLE
fix(docs): update Discord invite link

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -636,6 +636,7 @@ queryVector
 QueryWeaver
 QueryWeaver's
 QuickJS
+QwDXn
 quickstart
 Quickstart
 quorum

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Workflow](https://github.com/FalkorDB/docs/actions/workflows/pages/pages-build-deployment/badge.svg?branch=main)](https://github.com/FalkorDB/docs/actions/workflows/pages/pages-build-deployment)
-[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
+[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/6M4QwDXn2w)
 [![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)
 
 [![Trendshift](https://trendshift.io/api/badge/repositories/14787)](https://trendshift.io/repositories/14787)
@@ -156,5 +156,5 @@ FalkorDB itself is licensed under the [Server Side Public License v1 (SSPLv1)](h
 
 - **Documentation**: [https://docs.falkordb.com](https://docs.falkordb.com)
 - **GitHub Discussions**: [https://github.com/FalkorDB/FalkorDB/discussions](https://github.com/FalkorDB/FalkorDB/discussions)
-- **Discord**: [https://discord.gg/ErBEqN9E](https://discord.gg/ErBEqN9E)
+- **Discord**: [https://discord.gg/6M4QwDXn2w](https://discord.gg/6M4QwDXn2w)
 - **Website**: [https://www.falkordb.com](https://www.falkordb.com)

--- a/References/index.md
+++ b/References/index.md
@@ -14,7 +14,7 @@ redirect_from:
 * [FalkorDB Blog](https://www.falkordb.com/blog)
 * [FalkorDB GitHub](https://github.com/FalkorDB/FalkorDB)
 * [FalkorDB Demos](https://github.com/FalkorDB/demos)
-* [FalkorDB Discord Community](https://discord.gg/ErBEqN9E)
+* [FalkorDB Discord Community](https://discord.gg/6M4QwDXn2w)
 
 ## Videos
 
@@ -50,7 +50,7 @@ Cailliau, Pieter & Davis, Tim & Gadepally, Vijay & Kepner, Jeremy & Lipman, Roi 
   q1="Where can I find the FalkorDB source code?"
   a1="The FalkorDB source code is available on GitHub at [https://github.com/FalkorDB/FalkorDB](https://github.com/FalkorDB/FalkorDB). You can also find demo projects at [https://github.com/FalkorDB/demos](https://github.com/FalkorDB/demos)."
   q2="Is there a community forum or chat for FalkorDB?"
-  a2="Yes! FalkorDB has an active **Discord community** where you can ask questions, share projects, and connect with other users and the development team. Join at [https://discord.gg/ErBEqN9E](https://discord.gg/ErBEqN9E)."
+  a2="Yes! FalkorDB has an active **Discord community** where you can ask questions, share projects, and connect with other users and the development team. Join at [https://discord.gg/6M4QwDXn2w](https://discord.gg/6M4QwDXn2w)."
   q3="What is the relationship between FalkorDB and RedisGraph?"
   a3="FalkorDB **originated from the RedisGraph project**. Many older resources reference RedisGraph but remain relevant to understanding FalkorDB's architecture, query language, and design principles."
   q4="Are there academic papers about FalkorDB's architecture?"

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -248,7 +248,7 @@ document.addEventListener("DOMContentLoaded", function () {
     "https://github.com/FalkorDB/FalkorDB",
     "https://x.com/falkordb",
     "https://www.linkedin.com/company/falkordb",
-    "https://discord.gg/ErBEqN9E"
+    "https://discord.gg/6M4QwDXn2w"
   ]
 }
 </script>

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ permalink: /
 [![Trendshift](https://trendshift.io/api/badge/repositories/14787)](https://trendshift.io/repositories/14787)
 
 [![Docker Hub](https://img.shields.io/docker/pulls/falkordb/falkordb?label=Docker&style=flat-square)](https://hub.docker.com/r/falkordb/falkordb/)
-[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/ErBEqN9E)
+[![Discord](https://img.shields.io/discord/1146782921294884966?style=flat-square)](https://discord.gg/6M4QwDXn2w)
 [![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=flat-square)](https://app.falkordb.cloud)
 
 ![FalkorDB Docs Readme Banner](https://github.com/user-attachments/assets/201b07e1-ac6d-4593-98cf-e58946d7766c)

--- a/llms.txt
+++ b/llms.txt
@@ -94,5 +94,5 @@ FalkorDB runs as a Redis module (RESP and Bolt protocols) and is purpose-built f
 
 - [GitHub: FalkorDB](https://github.com/FalkorDB/FalkorDB): Source code and issue tracker.
 - [Docker Hub: falkordb/falkordb](https://hub.docker.com/r/falkordb/falkordb): Official Docker images.
-- [Discord Community](https://discord.gg/ErBEqN9E): Community chat and support.
+- [Discord Community](https://discord.gg/6M4QwDXn2w): Community chat and support.
 - [License: SSPLv1](https://github.com/FalkorDB/FalkorDB/blob/master/LICENSE.txt): Server Side Public License v1.


### PR DESCRIPTION
## Summary
Replace the deprecated Discord invite link with the new one across all documentation files.

## Changes
- **Old link:** `https://discord.gg/ErBEqN9E`
- **New link:** `https://discord.gg/6M4QwDXn2w`

## Testing
N/A — documentation-only change.

## Memory / Performance Impact
N/A

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Discord community invite link across documentation, homepage, references, and website metadata to direct users to the current community server.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/docs/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->