### PR TITLE
docs(cloud): remove Instance Type column from Pro Tier tables

### DIFF
--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -40,46 +40,46 @@ The Pro Tier provides a robust environment to scale your application with confid
 
 ## Standalone
 
-| Instance Type | Cores | Memory<br>(GB) | Max Graph<br>Dataset<br>(GB) | Hourly Cost | Monthly Cost |
-| :--- | :---: | :---: | :---: | ---: | ---: |
-| E2-medium | 1 | 4 | 2 | $0.240/hr | $175.20 |
-| t2.medium | 2 | 4 | 2 | $0.440/hr | $321.20 |
-| E2-standard-2 / m6i.large (Starting Instance) | 2 | 8 | 6 | $0.480/hr | $350.40 |
-| E2-standard-4 / m6i.xlarge | 4 | 16 | 12 | $0.960/hr | $700.80 |
-| E2-standard-8 / m6i.2xlarge | 8 | 32 | 24 | $1.920/hr | $1,401.60 |
-| E2-highmem-2 / r6i.large | 2 | 16 | 12 | $0.560/hr | $408.80 |
-| E2-highmem-4 / r6i.xlarge | 4 | 32 | 24 | $1.120/hr | $817.60 |
-| E2-highmem-8 / r6i.2xlarge | 8 | 64 | 48 | $2.240/hr | $1,635.20 |
-| m6i.4xlarge | 16 | 64 | 48 | $3.840/hr | $2,803.20 |
-| m6i.8xlarge | 32 | 128 | 96 | $7.680/hr | $5,606.40 |
-| r6i.4xlarge | 16 | 128 | 96 | $4.480/hr | $3,270.40 |
-| E2-custom-4-8192 / c6i.xlarge | 4 | 8 | 6 | $0.880/hr | $642.40 |
-| E2-custom-8-16384 / c6i.2xlarge | 8 | 16 | 12 | $1.760/hr | $1,284.80 |
-| E2-custom-16-32768 / c6i.4xlarge | 16 | 32 | 24 | $3.520/hr | $2,569.60 |
-| E2-custom-32-65536 / c6i.8xlarge | 32 | 64 | 48 | $7.040/hr | $5,139.20 |
+| Cores | Memory<br>(GB) | Max Graph<br>Dataset<br>(GB) | Hourly Cost | Monthly Cost |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | 4 | 2 | $0.240/hr | $175.20 |
+| 2 | 4 | 2 | $0.440/hr | $321.20 |
+| 2 | 8 | 6 | $0.480/hr | $350.40 |
+| 4 | 16 | 12 | $0.960/hr | $700.80 |
+| 8 | 32 | 24 | $1.920/hr | $1,401.60 |
+| 2 | 16 | 12 | $0.560/hr | $408.80 |
+| 4 | 32 | 24 | $1.120/hr | $817.60 |
+| 8 | 64 | 48 | $2.240/hr | $1,635.20 |
+| 16 | 64 | 48 | $3.840/hr | $2,803.20 |
+| 32 | 128 | 96 | $7.680/hr | $5,606.40 |
+| 16 | 128 | 96 | $4.480/hr | $3,270.40 |
+| 4 | 8 | 6 | $0.880/hr | $642.40 |
+| 8 | 16 | 12 | $1.760/hr | $1,284.80 |
+| 16 | 32 | 24 | $3.520/hr | $2,569.60 |
+| 32 | 64 | 48 | $7.040/hr | $5,139.20 |
 
 > Monthly Cost = Hourly Cost × 730 hours/month.
 
 ## Replicated (High Availability, Master (x1), Replica (x1))
 
 
-| Instance Type                                  | Cores | Memory<br>(GB) | Max Graph<br>Dataset<br>(GB) | Hourly Cost  | Monthly Cost |
-| :--------------------------------------------- | :---: | :---------: | :--------------------: | -----------: | -----------: |
-| E2-medium                                      |   1   |      4      |           2            |   \$0.900/hr |     \$657.00 |
-| t2.medium                                      |   2   |      4      |           2            |   \$1.300/hr |     \$949.00 |
-| E2-standard-2 / m6i.large (Starting Instance)  |   2   |      8      |           6            |   \$1.380/hr |   \$1,007.40 |
-| E2-standard-4 / m6i.xlarge                     |   4   |     16      |           12           |   \$2.340/hr |   \$1,708.20 |
-| E2-standard-8 / m6i.2xlarge                    |   8   |     32      |           24           |   \$4.260/hr |   \$3,109.80 |
-| E2-highmem-2 / r6i.large                       |   2   |     16      |           12           |   \$1.540/hr |   \$1,124.20 |
-| E2-highmem-4 / r6i.xlarge                      |   4   |     32      |           24           |   \$2.660/hr |   \$1,941.80 |
-| E2-highmem-8 / r6i.2xlarge                     |   8   |     64      |           48           |   \$4.900/hr |   \$3,577.00 |
-| m6i.4xlarge                                    |  16   |     64      |           48           |   \$8.100/hr |   \$5,913.00 |
-| m6i.8xlarge                                    |  32   |    128      |           96           |  \$15.780/hr |  \$11,519.40 |
-| r6i.4xlarge                                    |  16   |    128      |           96           |   \$9.380/hr |   \$6,847.40 |
-| E2-custom-4-8192 / c6i.xlarge                  |   4   |      8      |           6            |   \$2.180/hr |   \$1,591.40 |
-| E2-custom-8-16384 / c6i.2xlarge                |   8   |     16      |           12           |   \$3.940/hr |   \$2,876.20 |
-| E2-custom-16-32768 / c6i.4xlarge               |  16   |     32      |           24           |   \$7.460/hr |   \$5,445.80 |
-| E2-custom-32-65536 / c6i.8xlarge               |  32   |     64      |           48           |  \$14.500/hr |  \$10,585.00 |
+| Cores | Memory<br>(GB) | Max Graph<br>Dataset<br>(GB) | Hourly Cost | Monthly Cost |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | 4 | 2 | \$0.900/hr | \$657.00 |
+| 2 | 4 | 2 | \$1.300/hr | \$949.00 |
+| 2 | 8 | 6 | \$1.380/hr | \$1,007.40 |
+| 4 | 16 | 12 | \$2.340/hr | \$1,708.20 |
+| 8 | 32 | 24 | \$4.260/hr | \$3,109.80 |
+| 2 | 16 | 12 | \$1.540/hr | \$1,124.20 |
+| 4 | 32 | 24 | \$2.660/hr | \$1,941.80 |
+| 8 | 64 | 48 | \$4.900/hr | \$3,577.00 |
+| 16 | 64 | 48 | \$8.100/hr | \$5,913.00 |
+| 32 | 128 | 96 | \$15.780/hr | \$11,519.40 |
+| 16 | 128 | 96 | \$9.380/hr | \$6,847.40 |
+| 4 | 8 | 6 | \$2.180/hr | \$1,591.40 |
+| 8 | 16 | 12 | \$3.940/hr | \$2,876.20 |
+| 16 | 32 | 24 | \$7.460/hr | \$5,445.80 |
+| 32 | 64 | 48 | \$14.500/hr | \$10,585.00 |
 
 > Note: In the Replicated table, **Cores** and **Memory (GB)** are per instance. **Max Graph Dataset (GB)** is calculated as 2 GB for 4 GB containers and 75% of memory for containers larger than 4 GB. We charge an additional 2 cores and 2 GB for replication and cluster since they require an extra component (sentinel for replication and rebalancer for cluster).
 


### PR DESCRIPTION
## Summary
Remove the `Instance Type` column from the Pro Tier pricing tables and left-align the remaining columns for a cleaner layout.

## Changes
- Drop the `Instance Type` column from the **Standalone** table.
- Drop the `Instance Type` column from the **Replicated** table.
- Left-align all remaining columns (Cores, Memory, Max Graph Dataset, Hourly Cost, Monthly Cost).

## Testing
Docs-only change. Verified no `Instance Type` references remain in `cloud/pro-tier.md` and table rows still align.

## Memory / Performance Impact
N/A (docs-only).

## Related Issues
N/A