### PR TITLE
docs(cloud): clarify Free Tier has no persistence or backups on deletion

### DIFF
--- a/cloud/free-tier.md
+++ b/cloud/free-tier.md
@@ -40,7 +40,7 @@ The free tier provides everything you need to explore FalkorDB and build initial
 Need help? Email **[support@falkordb.com](mailto:support@falkordb.com)** to open a support ticket, or join the community on **[Discord](https://discord.com/invite/Y2mMT9VdMy)**. See the [Support page](/support/) for more details.
 
 ## Terms
-> ⚠️ Free instances that aren't utilized for 1 day will be stopped, and deleted after 7 days.
+> ⚠️ Free instances that aren't utilized for 1 day will be stopped, and deleted after 7 days. The Free Tier has no persistence and no backups. A deleted instance and its data cannot be recovered.
 Need an extension? Speak to [sales](https://www.falkordb.com/get-a-demo/)
 
 ## Getting Started
@@ -57,7 +57,7 @@ Need an extension? Speak to [sales](https://www.falkordb.com/get-a-demo/)
   q2="Do I need a credit card to sign up?"
   a2="No, the Free Tier requires no credit card. You can sign up and start using FalkorDB immediately at [app.falkordb.cloud/signup](https://app.falkordb.cloud/signup)."
   q3="What happens if my Free Tier instance is inactive?"
-  a3="Free instances that are not utilized for **1 day will be stopped**, and **deleted after 7 days** of inactivity. Contact [sales](https://www.falkordb.com/get-a-demo/) if you need an extension."
+  a3="Free instances that are not utilized for **1 day will be stopped**, and **deleted after 7 days** of inactivity. The Free Tier keeps **no snapshots and no backups**. Once an instance is deleted its data is permanently lost and cannot be recovered. Contact [sales](https://www.falkordb.com/get-a-demo/) if you need an extension."
   q4="Which cloud providers are available for the Free Tier?"
   a4="The Free Tier is available on both **AWS** and **GCP**. You choose your preferred provider during deployment."
   q5="What features are NOT included in the Free Tier?"


### PR DESCRIPTION
## Summary
Make it explicit that a stopped and deleted Free Tier instance cannot be recovered. The Free Tier has no persistence and no backups, so its data is permanently lost once the instance is deleted after 7 days of inactivity.

## Changes
- `cloud/free-tier.md`:
  - Terms callout now states the Free Tier has no persistence and no backups, and that a deleted instance and its data cannot be recovered.
  - FAQ answer (inactive instance) now states the Free Tier keeps no snapshots and no backups, and that data is permanently lost on deletion.

## Testing
Docs-only change. Verified copy against the pricing comparison table where Continuous Persistence and Automated Backups are both unavailable on the Free Tier.

## Memory / Performance Impact
N/A (docs-only).

## Related Issues
N/A

---
**Approver:** @dudizimber
FYI: @MuhammadQadora

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified free tier policies: instances are stopped after 1 day of inactivity and permanently deleted after 7 days with no recovery option.
  * Emphasized that free instances have no persistence, backups, or snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->