### PR TITLE
docs(cloud): add Stopped Instances terms to Startup tier

### DIFF
--- a/cloud/startup-tier.md
+++ b/cloud/startup-tier.md
@@ -53,6 +53,12 @@ The Startup Tier includes essential features like **TLS** and **Automated Backup
 > 
 > ⚠️ Prices are subject to change
 
+### Stopped Instances
+> An instance that is stopped will be removed after 14 days. Resume it within 14 days to keep it.
+
+### Snapshot Retention
+> Once an instance is removed we keep a snapshot for an additional 14 days.
+
 ## Getting Started
 
 <a href="https://www.youtube.com/watch?v=z0XO4pb2t5Y" target="_blank">

--- a/cloud/startup-tier.md
+++ b/cloud/startup-tier.md
@@ -56,6 +56,9 @@ The Startup Tier includes essential features like **TLS** and **Automated Backup
 ### Stopped Instances
 > An instance that is stopped will be removed after 14 days. Before removal, a snapshot will be taken containing its data, allowing it to be restored for the next 14 days.
 
+### Snapshots
+> All snapshots are automatically deleted after 14 days. This applies to every snapshot, including the one taken before a stopped instance is removed.
+
 ### Backups
 > Backups are taken automatically every 12h and retained for 7 days.
 

--- a/cloud/startup-tier.md
+++ b/cloud/startup-tier.md
@@ -54,10 +54,10 @@ The Startup Tier includes essential features like **TLS** and **Automated Backup
 > ⚠️ Prices are subject to change
 
 ### Stopped Instances
-> An instance that is stopped will be removed after 14 days. Resume it within 14 days to keep it.
+> An instance that is stopped will be removed after 14 days. Before removal, a snapshot will be taken containing its data, allowing it to be restored for the next 14 days.
 
-### Snapshot Retention
-> Once an instance is removed we keep a snapshot for an additional 14 days.
+### Backups
+> Backups are taken automatically every 12h and retained for 7 days.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Add a Stopped Instances policy to the Startup tier Terms section, alongside the existing pricing terms.

## Changes
- `cloud/startup-tier.md` Terms section gains two items:
  - **Stopped Instances**: a stopped instance is removed after 14 days. Resume within 14 days to keep it.
  - **Snapshot Retention**: after removal a snapshot is kept for an additional 14 days.

## Testing
Docs-only change. Follows existing Terms subsection structure.

## Memory / Performance Impact
N/A (docs-only).

## Related Issues
N/A

---
**Approver:** @dudizimber
FYI: @MuhammadQadora

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on stopped instance behavior: instances are removed after 14 days but can be resumed within that period. Snapshots are retained for an additional 14 days following instance removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->