### PR TITLE
docs(cloud): add Stopped Instances terms to Pro tier

### DIFF
--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -86,6 +86,14 @@ The Pro Tier provides a robust environment to scale your application with confid
 > Use our **[graph size calculator](https://www.falkordb.com/graph-database-graph-size-calculator/)** to further estimate your cost.
 > ⚠️ Prices are subject to change
 
+### Stopped Instances
+> An instance that is stopped will be removed after 14 days. Resume it within 14 days to keep it.
+
+### Snapshot Retention
+> Once an instance is removed we keep a snapshot for an additional 14 days.\*
+>
+> \* We recommend backing up your database on a frequent basis.
+
 ## Getting Started
 
 <a href="https://www.youtube.com/watch?v=UIzrW9otvYM" target="_blank">

--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -89,6 +89,9 @@ The Pro Tier provides a robust environment to scale your application with confid
 ### Stopped Instances
 > An instance that is stopped will be removed after 14 days. Before removal, a snapshot will be taken containing its data, allowing it to be restored for the next 14 days.
 
+### Snapshots
+> All snapshots are automatically deleted after 14 days. This applies to every snapshot, including the one taken before a stopped instance is removed.
+
 ### Backups
 > Backups are taken automatically every 12h and retained for 7 days.
 

--- a/cloud/pro-tier.md
+++ b/cloud/pro-tier.md
@@ -87,12 +87,10 @@ The Pro Tier provides a robust environment to scale your application with confid
 > ⚠️ Prices are subject to change
 
 ### Stopped Instances
-> An instance that is stopped will be removed after 14 days. Resume it within 14 days to keep it.
+> An instance that is stopped will be removed after 14 days. Before removal, a snapshot will be taken containing its data, allowing it to be restored for the next 14 days.
 
-### Snapshot Retention
-> Once an instance is removed we keep a snapshot for an additional 14 days.\*
->
-> \* We recommend backing up your database on a frequent basis.
+### Backups
+> Backups are taken automatically every 12h and retained for 7 days.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Add a Stopped Instances policy to the Pro tier Terms section, alongside the existing pricing terms.

## Changes
- `cloud/pro-tier.md` Terms section gains two items:
  - **Stopped Instances**: a stopped instance is removed after 14 days. Resume within 14 days to keep it.
  - **Snapshot Retention**: after removal a snapshot is kept for an additional 14 days, with a footnote recommending frequent database backups.

## Testing
Docs-only change. Follows existing Terms subsection structure.

## Memory / Performance Impact
N/A (docs-only).

## Related Issues
N/A

---
**Approver:** @dudizimber
FYI: @MuhammadQadora

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Pro pricing/usage details with new sections for **Stopped Instances**, including a 14-day removal window and snapshot-based restore for the next 14 days.
  * Added **Snapshots** retention guidance, including auto-deletion after 14 days (including pre-removal snapshots).
  * Added **Backups** details, including automatic backups every 12 hours with 7-day retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->