### PR TITLE
docs(cloud): add Stopped Instances terms to Enterprise tier

### DIFF
--- a/cloud/enterprise-tier.md
+++ b/cloud/enterprise-tier.md
@@ -43,12 +43,10 @@ The Enterprise Tier is fully optimized for mission-critical applications, provid
 > ⚠️ Prices are subject to change
 
 ### Stopped Instances
-> An instance that is stopped will be removed after 14 days. Resume it within 14 days to keep it.
+> An instance that is stopped will be removed after 14 days. Before removal, a snapshot will be taken containing its data, allowing it to be restored for the next 14 days.
 
-### Snapshot Retention
-> Once an instance is removed we keep a snapshot for an additional 14 days.\*
->
-> \* We recommend backing up your database on a frequent basis.
+### Backups
+> Backups are taken automatically every 2h and retained for 2 days.
 
 ## Getting Started
 

--- a/cloud/enterprise-tier.md
+++ b/cloud/enterprise-tier.md
@@ -45,6 +45,9 @@ The Enterprise Tier is fully optimized for mission-critical applications, provid
 ### Stopped Instances
 > An instance that is stopped will be removed after 14 days. Before removal, a snapshot will be taken containing its data, allowing it to be restored for the next 14 days.
 
+### Snapshots
+> All snapshots are automatically deleted after 14 days. This applies to every snapshot, including the one taken before a stopped instance is removed.
+
 ### Backups
 > Backups are taken automatically every 2h and retained for 2 days.
 

--- a/cloud/enterprise-tier.md
+++ b/cloud/enterprise-tier.md
@@ -42,6 +42,14 @@ The Enterprise Tier is fully optimized for mission-critical applications, provid
 >
 > ⚠️ Prices are subject to change
 
+### Stopped Instances
+> An instance that is stopped will be removed after 14 days. Resume it within 14 days to keep it.
+
+### Snapshot Retention
+> Once an instance is removed we keep a snapshot for an additional 14 days.\*
+>
+> \* We recommend backing up your database on a frequent basis.
+
 ## Getting Started
 
 <a href="https://www.youtube.com/watch?v=fu_8CLFKYSs" target="_blank">


### PR DESCRIPTION
## Summary
Add a Stopped Instances policy to the Enterprise tier Terms section, alongside the existing consultation and pricing terms.

## Changes
- `cloud/enterprise-tier.md` Terms section gains two items:
  - **Stopped Instances**: a stopped instance is removed after 14 days. Resume within 14 days to keep it.
  - **Snapshot Retention**: after removal a snapshot is kept for an additional 14 days, with a footnote recommending frequent database backups.

## Testing
Docs-only change. Follows existing Terms subsection structure.

## Memory / Performance Impact
N/A (docs-only).

## Related Issues
N/A

---
**Approver:** @dudizimber
FYI: @MuhammadQadora