### PR TITLE
fix(docs): correct broken LangGraph integration examples

### DIFF
--- a/genai-tools/langgraph.md
+++ b/genai-tools/langgraph.md
@@ -19,8 +19,17 @@ parent: "GenAI Tools"
 Install LangGraph with required dependencies:
 
 ```bash
-pip install langgraph langchain langchain-community falkordb langchain-openai
+pip install langgraph langgraph-checkpoint-sqlite langchain langchain-community falkordb langchain-openai
 ```
+
+{: .warning }
+> **`langchain-community` maintenance status**: `FalkorDBGraph` currently lives in the
+> [`langchain-community`](https://github.com/langchain-ai/langchain-community) package, which has been
+> archived and is no longer actively maintained. The examples below still work with the last published
+> release, but there is currently no drop-in successor package for the graph/schema wrapper (the standalone
+> `langchain-falkordb` package only covers chat message history and vector stores). Pin your
+> `langchain-community` version and monitor the [FalkorDB LangChain integration](./langchain.md)
+> page for updates.
 
 ## Quick Start
 
@@ -134,7 +143,6 @@ print(result["answer"])
 
 ```python
 from langgraph.graph import StateGraph, END
-from langgraph.prebuilt import ToolExecutor, ToolInvocation
 
 class RAGState(TypedDict):
     question: str
@@ -247,6 +255,15 @@ def should_continue(state: GraphState) -> str:
     else:
         return "continue"
 
+def handle_no_results(state: GraphState) -> GraphState:
+    """Handle the case where the query returned no data"""
+    state["answer"] = "No matching data was found in the graph for this question."
+    return state
+
+# handle_no_results must be registered before it can be used as a conditional edge target
+workflow.add_node("handle_no_results", handle_no_results)
+workflow.add_edge("handle_no_results", END)
+
 # Add conditional edges
 workflow.add_conditional_edges(
     "execute_query",
@@ -261,32 +278,47 @@ workflow.add_conditional_edges(
 
 ### Memory Integration
 
+Requires the `langgraph-checkpoint-sqlite` package (`pip install langgraph-checkpoint-sqlite`).
+`SqliteSaver.from_conn_string` is a context manager, so it must be used with `with`
+rather than assigned directly — otherwise `workflow.compile(checkpointer=...)` will
+raise a `TypeError` because it receives a context manager instead of a saver instance.
+
 ```python
 from langgraph.checkpoint.sqlite import SqliteSaver
-
-# Add persistence
-memory = SqliteSaver.from_conn_string(":memory:")
-
-# Compile with checkpointing
-app = workflow.compile(checkpointer=memory)
 
 # Use with thread ID for conversation memory
 config = {"configurable": {"thread_id": "user_123"}}
 
-result1 = app.invoke({
-    "question": "Who is the CEO?",
-    "cypher_query": "",
-    "graph_data": "",
-    "answer": "",
-}, config)
+# Add persistence (SqliteSaver must be used as a context manager)
+with SqliteSaver.from_conn_string(":memory:") as memory:
+    # Compile with checkpointing
+    app = workflow.compile(checkpointer=memory)
 
-result2 = app.invoke({
-    "question": "What companies do they lead?",
-    "cypher_query": "",
-    "graph_data": "",
-    "answer": "",
-}, config)
+    result1 = app.invoke({
+        "question": "Who is the CEO?",
+        "cypher_query": "",
+        "graph_data": "",
+        "answer": "",
+    }, config)
+
+    result2 = app.invoke({
+        "question": "What companies do they lead?",
+        "cypher_query": "",
+        "graph_data": "",
+        "answer": "",
+    }, config)
 ```
+
+{: .note }
+> For simple in-process memory that doesn't need to survive past the current run, you can skip
+> the extra dependency and use `InMemorySaver` from `langgraph.checkpoint.memory` instead, which
+> ships with `langgraph` itself:
+>
+> ```python
+> from langgraph.checkpoint.memory import InMemorySaver
+>
+> app = workflow.compile(checkpointer=InMemorySaver())
+> ```
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary
Reviewed https://docs.falkordb.com/genai-tools/langgraph.html end-to-end against a live FalkorDB instance and current package versions. Found and fixed 3 code bugs that break the documented examples verbatim, plus added a callout about an important upstream maintenance risk.

## Changes
- **Install command**: add `langgraph-checkpoint-sqlite`, which is required by the Memory Integration section's `from langgraph.checkpoint.sqlite import SqliteSaver` but was missing, causing `ModuleNotFoundError`.
- **Memory Integration**: fix `SqliteSaver.from_conn_string(":memory:")` usage. In current `langgraph-checkpoint-sqlite`, this is a `@contextmanager` generator — assigning its return value directly (as the doc did) yields a `_GeneratorContextManager`, not a saver, so `workflow.compile(checkpointer=memory)` raised `TypeError: Invalid checkpointer provided`. Now wrapped in `with ... as memory:`. Also added a note pointing to `InMemorySaver` (bundled with `langgraph`, no extra install) as a lighter alternative.
- **Multi-Agent GraphRAG System**: removed `from langgraph.prebuilt import ToolExecutor, ToolInvocation` — both symbols were removed from `langgraph.prebuilt`'s public API in current releases (`ImportError`), and neither was actually used anywhere in the example, so the import was simply dead and broken.
- **Conditional Routing**: the `should_continue` routing map targets a `"handle_no_results"` node that was never defined/registered anywhere in the doc. Copying the snippet into the Quick Start workflow made `workflow.compile()` raise `ValueError: ... found unknown target 'handle_no_results'`. Added the missing node function, `add_node`, and an edge to `END`.
- **New warning callout**: `FalkorDBGraph` (used throughout this page) lives in `langchain-community`, which was archived by the LangChain team on 2026-06-19 and is no longer maintained. The examples still work against the last published release, but there's currently no drop-in standalone successor package for the graph/schema wrapper (`langchain-falkordb` only covers chat history and vector stores). Flagged this so readers can make an informed choice and pin versions.

## Testing
- Spun up `falkordb/falkordb:edge` in Docker and installed current PyPI releases (`langgraph` 1.2.7, `langgraph-checkpoint-sqlite` 3.1.0, `langchain` 1.3.11, `langchain-community` 0.4.2, `falkordb` 1.6.1, `langchain-openai` 1.3.3).
- Reproduced all 4 bugs against the original doc content (import errors, `TypeError`, `ValueError`) before fixing.
- Extracted every corrected Python code block from the updated markdown and executed them in sequence (with a stand-in fake chat model in place of `ChatOpenAI`, since no OpenAI credentials are available in this environment) — all sections (Quick Start steps 1-4, Multi-Agent GraphRAG, Conditional Routing, Memory Integration, `InMemorySaver` alternative) ran successfully end-to-end with no errors.
- Verified all existing doc "Resources" links still resolve (200 OK).

## Memory / Performance Impact
N/A — documentation only.

## Related Issues
N/A — found via manual doc review, no pre-existing issue filed.
