### PR TITLE
fix(nav): pin mobile search box to top of menu

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -21,6 +21,30 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
 {% endif %}
 
+<!-- Mobile menu: keep the search box visible near the top -->
+<style>
+/*
+ * On mobile (< 50rem, matching Just the Docs' own nav breakpoint) the search
+ * box normally renders after the full nav list, so on pages with a long menu
+ * it gets pushed off-screen and is easy to miss. Pin it right below the site
+ * header instead, and reserve the same amount of space at the top of the nav
+ * list so its first item isn't hidden underneath the pinned search box.
+ */
+@media (max-width: 49.9375rem) {
+  .main-header.nav-open {
+    position: fixed;
+    top: 3.75rem;
+    left: 0;
+    z-index: 3;
+    width: 100%;
+  }
+
+  .site-nav.nav-open {
+    padding-top: 7.5rem;
+  }
+}
+</style>
+
 <!-- Sticky right-side Table of Contents -->
 <style>
 .toc-sidebar {


### PR DESCRIPTION
## Summary
On mobile, the search box is rendered by Just the Docs `components/header.html`, which is included **after** the full sidebar nav list in the DOM. On pages with a long menu (e.g. the Cypher section with 50+ links), the search box ends up pushed far below the fold when the mobile menu is opened, so it's effectively hidden until the user scrolls past the entire menu.

## Changes
- Added a small mobile-only (`max-width: 49.9375rem`, matching Just the Docs' own nav breakpoint) CSS override in `_includes/head_custom.html`:
  - Pins `.main-header.nav-open` (search box + aux nav links) directly under the site header (`position: fixed`) while the mobile menu is open.
  - Adds matching `padding-top` to `.site-nav.nav-open` so the first nav item isn't hidden underneath the pinned search box.
- Desktop layout (`>= 50rem`) is completely untouched — verified no style changes apply there.

## Testing
Verified locally with a Playwright-driven headless Chromium against the built site (no source/runtime changes to test infra; testing artifacts were not committed):
- Long-menu page (Cypher docs, 51 nav links) at 375×812 and 320×568: search box now appears immediately below the header with no overlap with the first nav item (~6.5px gap).
- Same page at 700×900 (theme's mid-size breakpoint with a different root font-size): still no overlap (~6.2px gap).
- Short-menu page (homepage): no overlap, consistent placement.
- Scrolling behavior: search box stays pinned/visible while the nav list scrolls underneath (no content permanently hidden).
- Search-active/focus state (typing a query) still works and expands full-screen as before.
- Desktop (1280×900): confirmed `main-header` keeps `position: static`/`display:flex` — unaffected.
- Re-validated with the actual 3-item `aux_links` config from `_config.yml` (FalkorDB.com / Docs Repository / FalkorDB Repository) to make sure the reserved spacing still holds.

## Memory / Performance Impact
N/A (docs site CSS-only change).

## Related Issues
N/A — reported directly by user (mobile search box hidden at bottom of long menu).