### PR TITLE
fix(nav): keep aux nav links single-line on narrow mobile widths

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -42,6 +42,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .site-nav.nav-open {
     padding-top: 7.5rem;
   }
+
+  /* Keep aux nav links on a single line (scrolling horizontally via the
+     theme's existing overflow-x: auto) instead of wrapping. Otherwise
+     #main-header grows taller on narrow screens or with more aux_links,
+     and the padding-top reserved above would no longer match its height. */
+  .aux-nav .site-button {
+    white-space: nowrap;
+  }
 }
 </style>
 


### PR DESCRIPTION
## Summary
Follow-up to #518 (already merged). Code review of that PR found a narrow-viewport edge case in the mobile search-box positioning fix: the `padding-top` reserved above the nav list assumes a fixed height for the pinned search box + aux nav row, but that height wasn't actually fixed.

## Changes
- On narrow viewports (e.g. ~280px, Galaxy Z Fold cover screen) or with a longer/additional `aux_links` entry, the aux nav button text wraps to a second line, growing `#main-header` taller than the reserved `padding-top`. This caused the pinned search box to overlap the first nav item's click target by a few pixels.
- Force aux nav links to stay single-line via `white-space: nowrap`, relying on the theme's own existing `overflow-x: auto` for horizontal scrolling instead of wrapping. This keeps `#main-header`'s height constant regardless of viewport width or `aux_links` content.

## Testing
Verified with headless Chromium (Playwright) at 280px, 320px, and 375px widths, using the real `_config.yml` `aux_links` (3 entries) and a stress test with a 4th, longer aux link appended — no overlap in any case after the fix. Desktop layout (>= 50rem) is untouched.

## Memory / Performance Impact
N/A — CSS-only change, no measurable perf impact.

## Related Issues
Follow-up to #518.