### PR TITLE
fix(nav): focus search input when mobile menu opens

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -45,6 +45,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 }
 </style>
 
+<!-- Mobile menu: move focus to search when the menu opens. The search box
+     now appears visually at the top of the mobile menu (see above), but
+     keyboard/screen-reader focus order still follows the unchanged DOM
+     order (nav links, then search). Moving focus to the search input on
+     open keeps focus order consistent with what's visually first, without
+     changing tab order for anyone not using the menu button.
+
+     Ordering notes for future maintainers:
+     - This listener is attached after Just the Docs' own (head_custom.html
+       is included after just-the-docs.js, see theme's _includes/head.html),
+       so nav-open has already been toggled by the time it runs.
+     - The check is intentionally synchronous (no setTimeout/microtask
+       deferral): iOS Safari only shows the on-screen keyboard for a
+       programmatic focus() call made synchronously within the original
+       click handler. Deferring the check would move focus silently
+       without opening the keyboard on iOS Safari, defeating the point of
+       this fix for a large share of mobile users. -->
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  var menuButton = document.getElementById("menu-button");
+  var mainHeader = document.getElementById("main-header");
+  var searchInput = document.getElementById("search-input");
+  if (!menuButton || !mainHeader || !searchInput) return;
+
+  menuButton.addEventListener("click", function () {
+    if (mainHeader.classList.contains("nav-open")) {
+      searchInput.focus();
+    }
+  });
+});
+</script>
+
 <!-- Sticky right-side Table of Contents -->
 <style>
 .toc-sidebar {


### PR DESCRIPTION
## Summary
Follow-up to #518 (already merged). Code review flagged a focus-order inconsistency introduced by that fix: the search box now appears visually at the top of the mobile menu, but keyboard/screen-reader Tab order is unchanged (nav links first, search last), since only CSS position moved, not DOM order.

## Changes
- Focus `#search-input` automatically when the mobile menu is opened, so keyboard focus lands where the search box now visually appears.
- The listener is attached in `head_custom.html`, which loads after `just-the-docs.js`, so by the time it runs the theme's own click handler has already toggled `nav-open` — no timing hacks (e.g. `setTimeout`) needed.
- Confirmed this does not prematurely trigger the expanded search-results UI (`.search-active` is gated on non-empty input, unaffected by focus alone) and has no effect on desktop, where the menu button is hidden (`display: none` at >= 50rem).

## Testing
Verified with headless Chromium (Playwright), injecting the change at its real position in `<head>` to preserve script execution/registration order:
- Opening the mobile menu moves focus to `#search-input`.
- Closing and reopening the menu re-focuses correctly each time.
- Typing after auto-focus still triggers search results normally (existing behavior unaffected).
- `Escape` still clears the input as before.
- Desktop (menu button hidden) is unaffected; programmatic click doesn't throw.

## Memory / Performance Impact
N/A — small JS listener, no measurable perf impact.

## Related Issues
Follow-up to #518.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile menu accessibility by automatically moving focus to the search field when the menu opens.
  * Better aligns keyboard and screen-reader focus with the visible order of items in the expanded mobile navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->