### PR TITLE
docs: add FalkorDB Cloud and Enterprise to Home navigation

### DIFF
--- a/cloud.mdx
+++ b/cloud.mdx
@@ -1,0 +1,26 @@
+---
+title: "FalkorDB Cloud"
+description: "FalkorDB Cloud is the fully managed FalkorDB service, with provisioning, scaling, backups, and monitoring handled for you."
+---
+
+FalkorDB Cloud is the fully managed version of FalkorDB. You get a running graph database in minutes without provisioning servers, tuning persistence, or managing upgrades.
+
+## What You Get
+
+- **Managed instances** across AWS, GCP, and Azure regions.
+- **Automated backups and snapshots** so your data survives failures.
+- **Monitoring and alerting** built into the console.
+- **Scaling on demand** as your graph and workload grow.
+- **A provisioning API** for creating and managing instances programmatically.
+
+## Service Tiers
+
+FalkorDB Cloud offers a Free tier for evaluation, plus Startup, Pro, and Enterprise tiers for production workloads. Each tier differs in memory, persistence, availability, and support.
+
+## Get Started
+
+Create an instance in the [FalkorDB Cloud console](https://app.falkordb.cloud/signup).
+
+Full Cloud documentation, including tier details, operations guides, and the complete API reference, lives at [docs.falkordb.cloud](https://docs.falkordb.cloud).
+
+For pricing and plan comparisons, see [falkordb.com/plans](https://www.falkordb.com/plans/).

--- a/docs.json
+++ b/docs.json
@@ -32,6 +32,8 @@
                 "group": "Home",
                 "pages": [
                   "index",
+                  "cloud",
+                  "enterprise",
                   "datatypes",
                   "support"
                 ]

--- a/enterprise.mdx
+++ b/enterprise.mdx
@@ -1,0 +1,24 @@
+---
+title: "FalkorDB Enterprise"
+description: "FalkorDB Enterprise is the self-managed distribution of FalkorDB, deployed on your own infrastructure or Kubernetes clusters."
+---
+
+FalkorDB Enterprise is the self-managed distribution of FalkorDB. It runs inside your own environment, so your data never leaves your infrastructure.
+
+## What You Get
+
+- **Deployment on your own clusters**, on Kubernetes or on Linux hosts.
+- **Offline installation** for environments without internet access.
+- **High availability and replication** for production workloads.
+- **Enterprise support** with defined response times.
+- **Licensing and access** managed through the customer portal.
+
+## Deployment Options
+
+FalkorDB Enterprise ships as a Helm chart for Kubernetes and as an embedded cluster installer for Linux. See the [Kubernetes guides](/operations/kubeblocks) for cluster deployment patterns.
+
+## Get Started
+
+Enterprise access is provisioned per customer. To request a license, an evaluation, or a technical walkthrough, [book a demo](https://www.falkordb.com/get-a-demo/) or contact [info@falkordb.com](mailto:info@falkordb.com).
+
+Existing customers can reach the support team at [support@falkordb.com](mailto:support@falkordb.com). See the [Support](/support) page for what to include in a ticket.


### PR DESCRIPTION
## Summary

Adds **FalkorDB Cloud** and **FalkorDB Enterprise** to the Home group in the sidebar, directly below **FalkorDB**, so both offerings are discoverable from the main documentation navigation.

Until now the only pointers to Cloud and Enterprise were entries in the product switcher, which is collapsed by default and easy to miss.

### Why these are pages and not links

Mintlify does not allow external links inside a group `pages` array. Verified against the live schema at `https://mintlify.com/docs.json` (mint 4.2.805): each `pages` entry resolves to either a page path string or a nested group object whose allowed keys are `group, graphql, sdk, public, boost, icon, hidden, searchable, root, tag, expanded, directory, openapi, asyncapi, pages`, with `additionalProperties: false`. There is no `href`.

External links are only valid on `products`, `tabs`, `anchors`, `dropdowns`, `menu` items, and `navigation.global.anchors`. None of those render inside the Home group, so real MDX pages are the only way to get entries in that position.

## Changes

- `cloud.mdx`: short landing page covering managed instances, backups, monitoring, scaling, and the provisioning API. Links to the Cloud console, the Cloud docs site, and the plans page.
- `enterprise.mdx`: short landing page covering self managed deployment, offline installation, high availability, and support. Links to the Kubernetes guides, the demo form, and support contacts.
- `docs.json`: inserts `cloud` and `enterprise` into the Home group between `index` and `datatypes`.

## Testing

- `node scripts/check_mdx.mjs` passes, 192 files, 0 syntax errors.
- `mint broken-links` passes, no broken links found.
- Verified locally with `mint dev`. Sidebar now renders `Home > FalkorDB > FalkorDB Cloud > FalkorDB Enterprise > Data types > Support`. Both pages return 200.
- Checked every new term against `.wordlist.txt` and existing page usage for the spellcheck job.

## Memory / Performance Impact

N/A. Documentation only.

## Related Issues

Follow up to #544. The Cloud content now lives in `FalkorDB/falkordb-cloud-docs`, and this restores a discovery path to it from the main docs.

### Note for reviewers

`cloud.mdx` links to `https://docs.falkordb.cloud`, which does not resolve yet. Same for `https://docs.enterprise.falkordb.com`, already referenced by the existing product switcher entries in `docs.json` on `main`. The Cloud link is intentional since that site is being prepared in `FalkorDB/falkordb-cloud-docs`. Enterprise points at live destinations instead, because its content is a gated Replicated portal rather than a public docs site. Happy to swap any target.
