### PR TITLE
Extend meta tags in documentation for improved SEO

### DIFF
--- a/agentic-memory/cognee.mdx
+++ b/agentic-memory/cognee.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cognee"
-description: "Build flexible agentic memory with Cognee and FalkorDB"
+description: "Give AI agents persistent memory with Cognee and FalkorDB, combining graph storage and vector search into a context-aware knowledge layer."
 ---
 
 [Cognee](https://github.com/topoteretes/cognee) is a memory management framework for AI agents that provides a flexible approach to storing and retrieving knowledge. It combines graph database capabilities with vector storage to create rich, context-aware memory systems.

--- a/algorithms/maxflow.mdx
+++ b/algorithms/maxflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Max Flow"
-description: "Max Flow"
+description: "Compute the maximum flow routable from source nodes to sink nodes in a directed, weighted FalkorDB graph, for throughput, routing, and matching problems."
 ---
 
 ## Overview

--- a/algorithms/maxflow.mdx
+++ b/algorithms/maxflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Max Flow"
-description: "Compute the maximum flow routable from source nodes to sink nodes in a directed, weighted FalkorDB graph, for throughput, routing, and matching problems."
+description: "Compute the maximum flow that can be routed from source nodes to sink nodes in a directed, weighted FalkorDB graph, for throughput, routing, and matching problems."
 ---
 
 ## Overview

--- a/algorithms/msf.mdx
+++ b/algorithms/msf.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MSF"
-description: "Minimum Spanning Forest Algorithm"
+description: "Compute the minimum spanning forest of a weighted FalkorDB graph — one minimum spanning tree per connected component, containing no cycles."
 ---
 
 The Minimum Spanning Forest algorithm computes the minimum spanning forest of a

--- a/algorithms/wcc.mdx
+++ b/algorithms/wcc.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Weakly Connected Components (WCC)"
-description: "Weakly Connected Components (WCC)"
+description: "Find weakly connected components in FalkorDB: groups of nodes reachable from one another when edge direction is ignored, for community detection and data cleaning."
 ---
 
 ## Overview

--- a/browser/ui/table-view.mdx
+++ b/browser/ui/table-view.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Table View"
-description: "Tabular query results view, search/expand behaviors, and CSV export."
+description: "The FalkorDB Browser Table tab renders query results as rows and columns, with automatic headers, search, nested value expansion, and CSV export."
 ---
 
 The Table tab displays query results as rows/columns when the query returns tabular data.

--- a/commands/graph.config-set.mdx
+++ b/commands/graph.config-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.CONFIG-SET"
-description: "Updates a FalkorDB configuration"
+description: "GRAPH.CONFIG SET updates one or more FalkorDB configuration parameters at runtime. Values are not persisted across a server restart."
 ---
 
 Set the value of a FalkorDB configuration parameter.

--- a/commands/graph.constraint-drop.mdx
+++ b/commands/graph.constraint-drop.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.CONSTRAINT DROP"
-description: "Deletes a constraint from specified graph"
+description: "GRAPH.CONSTRAINT DROP removes a mandatory or unique constraint from a node label or relationship type in a FalkorDB graph."
 ---
 
 ```sh

--- a/commands/graph.copy.mdx
+++ b/commands/graph.copy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.COPY"
-description: "Creates a copy of the given graph"
+description: "GRAPH.COPY duplicates an existing graph under a new key, while the source graph stays fully accessible for the duration of the copy."
 ---
 
 Usage: `GRAPH.COPY <src> <dest>`

--- a/commands/graph.explain.mdx
+++ b/commands/graph.explain.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.EXPLAIN"
-description: "Returns a query execution plan without running the query"
+description: "GRAPH.EXPLAIN returns the execution plan FalkorDB would use for a query without running it, so you can inspect and tune query performance."
 ---
 
 Constructs a query execution plan but does not run it. Inspect this execution plan to better

--- a/commands/graph.list.mdx
+++ b/commands/graph.list.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.LIST"
-description: "Lists all graph keys in the keyspace"
+description: "GRAPH.LIST returns the name of every graph key stored in the FalkorDB keyspace, with examples in Python, JavaScript, Java, and Rust."
 ---
 
 Lists all graph keys in the keyspace.

--- a/commands/graph.memory.mdx
+++ b/commands/graph.memory.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.MEMORY"
-description: "The GRAPH.MEMORY USAGE command returns detailed memory usage statistics for the specified graph. This command provides insight into how much memory is used by various internal data structures such as nodes, edges, schemas, and indices. It enables users to analyze memory consumption at the graph level, reporting statistics in megabytes (MB). This is useful for debugging, monitoring, performance optimization, and capacity planning in FalkorDB deployments."
+description: "GRAPH.MEMORY USAGE reports per-graph memory consumption in megabytes, broken down by nodes, edges, schemas, and indices, for monitoring and capacity planning."
 ---
 
 The `GRAPH.MEMORY` command returns detailed memory consumption statistics for a specific graph in **megabytes (MB)**. It provides insight into how much memory is used by various internal data structures such as nodes, edges, schemas, indices, and matrix representations. This command can be used to monitor memory consumption at the graph level, making it especially useful for debugging, monitoring, performance optimization, and capacity planning in FalkorDB deployments.

--- a/commands/graph.query.mdx
+++ b/commands/graph.query.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.QUERY"
-description: "Executes the given query against a specified graph"
+description: "GRAPH.QUERY runs an openCypher query against a FalkorDB graph and returns a result set, with optional query timeout and compact result format."
 ---
 
 Executes the given query against a specified graph.

--- a/commands/graph.ro-query.mdx
+++ b/commands/graph.ro-query.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GRAPH.RO_QUERY"
-description: "Executes a given read only query against a specified graph"
+description: "GRAPH.RO_QUERY runs a read-only openCypher query against a FalkorDB graph and returns an error if the query attempts any write."
 ---
 
 Executes a given read only query against a specified graph.

--- a/commands/index.mdx
+++ b/commands/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Commands"
-description: "Commands overview"
+description: "Reference for every FalkorDB command, from running openCypher queries with GRAPH.QUERY to managing configuration, constraints, indexes, and graph metadata."
 ---
 
 ## FalkorDB Features

--- a/cypher/known-limitations.mdx
+++ b/cypher/known-limitations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Known limitations"
-description: "FalkorDB Known limitations"
+description: "Known limitations of the FalkorDB Cypher implementation, including relationship uniqueness in match patterns and other behaviors that differ from openCypher."
 ---
 
 ## Relationship uniqueness in patterns

--- a/cypher/order-by.mdx
+++ b/cypher/order-by.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ORDER BY"
-description: "Order by specifies that the output be sorted and how."
+description: "Sort query results in FalkorDB with the Cypher ORDER BY clause, ordering by one or more properties in ascending or descending order."
 ---
 
 Order by specifies that the output be sorted and how.

--- a/cypher/procedures.mdx
+++ b/cypher/procedures.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Procedures"
-description: "Calling procedures using CALL and YIELD."
+description: "Call built-in FalkorDB procedures from Cypher with the CALL and YIELD clauses, including a reference table of available procedures and the values they yield."
 ---
 
 Procedures are functions that can be called from within Cypher queries using the `CALL` syntax.

--- a/cypher/where.mdx
+++ b/cypher/where.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WHERE"
-description: "Optional clause used to filter results based on predicates."
+description: "Filter query results in FalkorDB with the Cypher WHERE clause, using comparison operators, string predicates such as CONTAINS and STARTS WITH, and boolean logic."
 ---
 
 The `WHERE` clause is optional and is used to filter results based on predicates (conditions).

--- a/design/client-spec.mdx
+++ b/design/client-spec.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Client Specification"
-description: "Technical specification for writing FalkorDB client libraries"
+description: "What a FalkorDB client library needs to implement: the compact result set format, value decoding, procedure calls for resolving labels and property keys, and reference clients."
 ---
 
 By design, there is not a full standard for FalkorDB clients to adhere to. Areas such as pretty-print formatting, query validation, and transactional and multithreaded capabilities have no canonically correct behavior, and the implementer is free to choose the approach and complexity that suits them best.

--- a/design/index.mdx
+++ b/design/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The FalkorDB Design"
-description: "FalkorDB: A High Performance In-Memory Graph Database"
+description: "How FalkorDB represents graphs internally using sparse adjacency matrices and linear algebra, and the design decisions behind the engine."
 ---
 
 ## Abstract

--- a/design/third-party.mdx
+++ b/design/third-party.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Third Party"
-description: "Third-Party Components in FalkorDB"
+description: "The third-party libraries bundled with FalkorDB, including GraphBLAS and xxHash, together with the open-source license that covers each one."
 ---
 
 FalkorDB uses several third-party libraries to enhance its functionality. 

--- a/docs.json
+++ b/docs.json
@@ -1708,10 +1708,10 @@
   ],
   "seo": {
     "metatags": {
-      "og:image": "/images/falkor-logo.png",
+      "og:image": "https://docs.falkordb.com/images/falkor-logo.png",
       "og:image:alt": "FalkorDB — the high-performance graph database for GraphRAG and GenAI",
       "og:locale": "en_US",
-      "twitter:image": "/images/falkor-logo.png",
+      "twitter:image": "https://docs.falkordb.com/images/falkor-logo.png",
       "twitter:image:alt": "FalkorDB — the high-performance graph database for GraphRAG and GenAI",
       "twitter:card": "summary_large_image",
       "twitter:site": "@FalkorDB",

--- a/docs.json
+++ b/docs.json
@@ -1709,8 +1709,34 @@
   "seo": {
     "metatags": {
       "og:image": "/images/falkor-logo.png",
+      "og:image:alt": "FalkorDB — the high-performance graph database for GraphRAG and GenAI",
+      "og:locale": "en_US",
       "twitter:image": "/images/falkor-logo.png",
-      "twitter:card": "summary_large_image"
+      "twitter:image:alt": "FalkorDB — the high-performance graph database for GraphRAG and GenAI",
+      "twitter:card": "summary_large_image",
+      "twitter:site": "@FalkorDB",
+      "twitter:creator": "@FalkorDB",
+      "author": "FalkorDB",
+      "publisher": "FalkorDB",
+      "application-name": "FalkorDB Docs",
+      "robots": "index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1",
+      "googlebot": "index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1",
+      "keywords": "FalkorDB, graph database, GraphRAG, knowledge graph, Cypher, OpenCypher, vector search, GenAI, RAG, RedisGraph, sparse matrix, linear algebra"
+    },
+    "organization": {
+      "id": "https://www.falkordb.com/#organization",
+      "name": "FalkorDB",
+      "legalName": "FalkorDB Inc.",
+      "url": "https://www.falkordb.com",
+      "logo": "https://docs.falkordb.com/images/falkor-logo.png",
+      "sameAs": [
+        "https://github.com/FalkorDB/FalkorDB",
+        "https://x.com/FalkorDB",
+        "https://www.linkedin.com/company/falkordb",
+        "https://discord.com/invite/6M4QwDXn2w",
+        "https://www.youtube.com/@falkordb",
+        "https://www.reddit.com/r/falkordb/"
+      ]
     }
   }
 }

--- a/genai-tools/llamaindex.mdx
+++ b/genai-tools/llamaindex.mdx
@@ -1,6 +1,6 @@
 ---
 title: "LlamaIndex"
-description: "Build efficient GraphRAG systems with LlamaIndex and FalkorDB."
+description: "Build GraphRAG applications with LlamaIndex and FalkorDB, using Cypher-powered retrieval over a knowledge graph to ground LLM responses in your own data."
 ---
 
 [LlamaIndex](https://www.llamaindex.ai/) is an open-source framework designed to simplify the development of LLM-powered applications. It provides tools for ingesting, indexing, and querying diverse data sources.

--- a/getting-started/index.mdx
+++ b/getting-started/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Getting Started"
-description: "Getting Started with FalkorDB Graph Database."
+description: "Set up FalkorDB, model a social network as a graph, and query it with Cypher through any of the official FalkorDB client libraries."
 ---
 
 This guide will walk you through setting up FalkorDB, modeling a social network as a graph, and accessing it using one of the [FalkorDB client libraries](/getting-started/clients) with the [Cypher](/cypher) query language.

--- a/integration/index.mdx
+++ b/integration/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integration"
-description: "Learn how to integrate FalkorDB into your applications with REST APIs"
+description: "Integrate FalkorDB with your applications and workflows using its REST API, official client SDKs, and framework adapters for low-latency graph workloads."
 ---
 
 The Integration section of the FalkorDB documentation provides all the necessary guidance for connecting 

--- a/integration/jena.mdx
+++ b/integration/jena.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Apache Jena"
-description: "How to use FalkorDB with Apache Jena via the jena-falkordb-adapter."
+description: "Use FalkorDB as an RDF backend for Apache Jena through the jena-falkordb-adapter, running SPARQL queries over graph data stored in FalkorDB."
 ---
 
 This page describes how to integrate FalkorDB with [Apache Jena](https://jena.apache.org/) using the [jena-falkordb-adapter](https://github.com/FalkorDB/jena-falkordb-adapter).

--- a/operations/docker.mdx
+++ b/operations/docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Docker and Docker Compose"
-description: "Running FalkorDB with Docker and Docker Compose"
+description: "Run FalkorDB with Docker and Docker Compose, covering the falkordb, falkordb-server, and falkordb-browser images plus authentication, persistence, and custom configuration."
 ---
 
 This guide covers how to run FalkorDB using Docker and Docker Compose, providing flexible deployment options for both development and production environments.

--- a/operations/falkordblite/falkordblite-py.mdx
+++ b/operations/falkordblite/falkordblite-py.mdx
@@ -1,6 +1,6 @@
 ---
 title: "FalkorDBLite (Python)"
-description: "Self-contained Python interface to FalkorDB for Python apps"
+description: "Embed FalkorDB in a Python application with FalkorDBLite, which installs, configures, and manages a local FalkorDB server for you — no separate database to run."
 ---
 
 FalkorDBLite is a self-contained Python interface to the FalkorDB graph database. It provides an embedded Redis server with the FalkorDB module that is automatically installed, configured, and managed when the bindings are used.

--- a/operations/falkordblite/falkordblite-ts.mdx
+++ b/operations/falkordblite/falkordblite-ts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "FalkorDBLite (TypeScript)"
-description: "Embedded FalkorDB runtime for Node.js and TypeScript"
+description: "Embed FalkorDB in a Node.js or TypeScript process with FalkorDBLite, a zero-config graph database that starts and stops with your app — ideal for development, demos, and CI."
 ---
 
 FalkorDBLite for Node.js/TypeScript launches an embedded `redis-server` with the FalkorDB module and returns a connected FalkorDB client. It is ideal for local development, demos, CI jobs, or small apps that want a zero-config graph database that starts and stops with the application.

--- a/operations/k8s-support.mdx
+++ b/operations/k8s-support.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Kubernetes support"
-description: "Deploy FalkorDB to Kubernetes."
+description: "Deploy FalkorDB on Kubernetes step by step with the Helm chart and the official Docker image, including the values.yaml settings the FalkorDB image requires."
 ---
 
 FalkorDB can be deployed on Kubernetes using Helm charts and Docker images. This guide will walk you through the process.

--- a/operations/kubeblocks.mdx
+++ b/operations/kubeblocks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "KubeBlocks"
-description: "Deploy FalkorDB on Kubernetes with KubeBlocks"
+description: "Deploy and manage FalkorDB on Kubernetes with the KubeBlocks operator, which handles provisioning, scaling, and day-two operations for stateful workloads."
 ---
 
 [KubeBlocks](https://kubeblocks.io) is a cloud-native database management operator that simplifies the deployment and management of databases on Kubernetes. This guide demonstrates how to deploy and manage FalkorDB using the KubeBlocks operator.

--- a/operations/migration/kuzu-to-falkordb.mdx
+++ b/operations/migration/kuzu-to-falkordb.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Kuzu to FalkorDB"
-description: "Migrate from Kuzu to FalkorDB."
+description: "Migrate a Kuzu graph database to FalkorDB in two steps, using automatic schema discovery, CSV export, and the FalkorDB bulk loader."
 ---
 
 A streamlined 2-step process to migrate data from Kuzu graph database into FalkorDB using automated schema discovery and CSV export.

--- a/operations/migration/neo4j-to-falkordb.mdx
+++ b/operations/migration/neo4j-to-falkordb.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Neo4j to FalkorDB"
-description: "Migrate from Neo4j to FalkorDB."
+description: "Migrate nodes, relationships, constraints, and indexes from Neo4j to FalkorDB using Cypher exports, CSV files, and a final validation pass."
 ---
 
 Migrating graph database contents from Neo4j to FalkorDB is straightforward using standard Cypher queries to extract data, transform labels and properties as needed, and load CSV files into FalkorDB. This process migrates nodes, edges, constraints, and indexes.

--- a/operations/migration/redisgraph-to-falkordb.mdx
+++ b/operations/migration/redisgraph-to-falkordb.mdx
@@ -1,6 +1,6 @@
 ---
 title: "RedisGraph to FalkorDB"
-description: "Migrate from RedisGraph to FalkorDB."
+description: "Migrate from RedisGraph to FalkorDB using an existing RDB snapshot. FalkorDB is fully compatible with RedisGraph RDB files, so no data conversion is needed."
 ---
 
 FalkorDB is fully compatible with RedisGraph RDB (Redis Database) files, making migration straightforward.

--- a/operations/migration/sql-to-falkordb.mdx
+++ b/operations/migration/sql-to-falkordb.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SQL Sources to FalkorDB (Online Migration)"
-description: "Online migration and incremental sync from SQL sources (BigQuery, ClickHouse, Databricks, MariaDB, MySQL, PostgreSQL, Snowflake, Spark SQL, SQL Server) into FalkorDB using DM-SQL-to-FalkorDB loaders and control plane."
+description: "Run an online migration and incremental sync into FalkorDB from SQL sources such as PostgreSQL, MySQL, BigQuery, Snowflake, and ClickHouse using DM-SQL-to-FalkorDB."
 ---
 
 The [DM-SQL-to-FalkorDB](https://github.com/FalkorDB/DM-SQL-to-FalkorDB) repository provides Rust-based CLI loaders for initial load and ongoing sync from SQL sources into FalkorDB.

--- a/udfs/flex/collections/intersection.mdx
+++ b/udfs/flex/collections/intersection.mdx
@@ -1,6 +1,6 @@
 ---
 title: "coll.intersection"
-description: "Returns a list of elements that appear in both input lists."
+description: "flex.coll.intersection returns a new list holding only the elements that appear in both input lists, callable directly from a Cypher query."
 ---
 
 ## Description

--- a/udfs/flex/map/fromPairs.mdx
+++ b/udfs/flex/map/fromPairs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "map.fromPairs"
-description: "Converts a list of [key, value] pairs into a map."
+description: "flex.map.fromPairs converts a list of two-element key-value arrays into a map, so Cypher queries can build maps dynamically."
 ---
 
 ## Description

--- a/udfs/flex/map/removeKey.mdx
+++ b/udfs/flex/map/removeKey.mdx
@@ -1,6 +1,6 @@
 ---
 title: "map.removeKey"
-description: "Returns a copy of a map with a single specified key removed."
+description: "flex.map.removeKey returns a copy of a map with a single key removed, leaving the original map unchanged. Callable directly from Cypher."
 ---
 
 ## Description

--- a/udfs/flex/map/removeKeys.mdx
+++ b/udfs/flex/map/removeKeys.mdx
@@ -1,6 +1,6 @@
 ---
 title: "map.removeKeys"
-description: "Returns a copy of a map with multiple specified keys removed."
+description: "flex.map.removeKeys returns a copy of a map with several keys removed at once, leaving the original map unchanged. Callable directly from Cypher."
 ---
 
 ## Description

--- a/udfs/flex/text/repeat.mdx
+++ b/udfs/flex/text/repeat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "text.repeat"
-description: "Returns a string repeated a specified number of times."
+description: "flex.text.repeat returns a new string made of the input string repeated a given number of times, callable directly from a Cypher query."
 ---
 
 ## Description


### PR DESCRIPTION
This pull request enhances the SEO capabilities of the documentation by extending the meta tags in the `docs.json` file and improving the descriptions across various `.mdx` pages. 

### Changes made:
- **Updated `docs.json`:** 
  - Extended the `seo` block to include missing meta tags such as `twitter:site`, `twitter:creator`, `og:image:alt`, and `robots` directives.
  - Added a new `seo.organization` block with JSON-LD for better search engine consolidation.

- **Revised descriptions in 39 `.mdx` pages:**
  - Improved the quality of existing descriptions, ensuring they are now between 70 and 186 characters, averaging 127 characters.
  - Addressed previously thin descriptions and ensured they are informative for search snippets.

### Verification:
- Validated `docs.json` against the Mintlify schema with no errors.
- Confirmed that all `.mdx` files compile without syntax errors.
- Ensured that the changes do not introduce any new lint errors.

These updates aim to enhance the visibility and searchability of the documentation, aligning it with best practices for SEO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved descriptions across algorithm, command, Cypher, integration, operations, migration, and UDF documentation.
  * Clarified query behavior, graph operations, deployment options, migration workflows, and embedded database usage.
  * Expanded getting-started and AI tooling guidance, including GraphRAG and persistent memory capabilities.
  * Enhanced SEO metadata and structured organization information.
  * Added clearer explanations of Table View features, client specifications, design topics, and third-party licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->