### PR TITLE
fix(redirects): add redirects for legacy memory-usage and migration URLs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -808,6 +808,14 @@
       "destination": "/commands/graph.list"
     },
     {
+      "source": "/commands/graph.memory-usage",
+      "destination": "/commands/graph.memory"
+    },
+    {
+      "source": "/commands/graph.memory-usage.html",
+      "destination": "/commands/graph.memory"
+    },
+    {
       "source": "/commands/graph.memory.html",
       "destination": "/commands/graph.memory"
     },
@@ -1342,6 +1350,50 @@
     {
       "source": "/migration.html",
       "destination": "/operations/migration"
+    },
+    {
+      "source": "/migration/index.html",
+      "destination": "/operations/migration"
+    },
+    {
+      "source": "/migration/kuzu-to-falkordb",
+      "destination": "/operations/migration/kuzu-to-falkordb"
+    },
+    {
+      "source": "/migration/kuzu-to-falkordb.html",
+      "destination": "/operations/migration/kuzu-to-falkordb"
+    },
+    {
+      "source": "/migration/neo4j-to-falkordb",
+      "destination": "/operations/migration/neo4j-to-falkordb"
+    },
+    {
+      "source": "/migration/neo4j-to-falkordb.html",
+      "destination": "/operations/migration/neo4j-to-falkordb"
+    },
+    {
+      "source": "/migration/rdf-to-falkordb",
+      "destination": "/operations/migration/rdf-to-falkordb"
+    },
+    {
+      "source": "/migration/rdf-to-falkordb.html",
+      "destination": "/operations/migration/rdf-to-falkordb"
+    },
+    {
+      "source": "/migration/redisgraph-to-falkordb",
+      "destination": "/operations/migration/redisgraph-to-falkordb"
+    },
+    {
+      "source": "/migration/redisgraph-to-falkordb.html",
+      "destination": "/operations/migration/redisgraph-to-falkordb"
+    },
+    {
+      "source": "/migration/sql-to-falkordb",
+      "destination": "/operations/migration/sql-to-falkordb"
+    },
+    {
+      "source": "/migration/sql-to-falkordb.html",
+      "destination": "/operations/migration/sql-to-falkordb"
     },
     {
       "source": "/opentelemetry",


### PR DESCRIPTION
## Problem

A crawl of falkordb.com blog posts surfaced 404s on two `docs.falkordb.com` URLs that are linked externally:

| URL | Status |
| --- | --- |
| `/commands/graph.memory-usage.html` | 404 |
| `/migration/kuzu-to-falkordb.html` | 404 |

Both are legacy paths left behind by past content moves:

- `commands/graph.memory-usage.md` was deleted in `3ef05a3` ("remove redundant memory usage doc page") in favor of `commands/graph.memory`, with no redirect added.
- The top-level `migration/` folder moved to `operations/migration/` in `ffb70b8`. Only `/migration` and `/migration.html` got redirects, so every child page URL broke.

I verified the rest of that family is broken too — `/migration/index.html`, `/migration/neo4j-to-falkordb.html`, `/migration/rdf-to-falkordb.html` and `/migration/redisgraph-to-falkordb.html` all return 404 today.

## Change

Adds redirects in `docs.json`:

- `/commands/graph.memory-usage` and `.html` → `/commands/graph.memory`
- `/migration/index.html` → `/operations/migration`
- `/migration/{kuzu,neo4j,rdf,redisgraph,sql}-to-falkordb` and `.html` → `/operations/migration/*`

Fixing the whole `/migration/*` family rather than only the reported page, since the same move broke all of them.

## Notes

The crawl also flagged `https://trust.falkordb.com/` as 403. That is not a real broken link — it is a crawler block on the Vanta-hosted trust center, which returns 200 to a normal request. It is also outside this repository.

## Validation

- `docs.json` parses; 325 redirects, no duplicate sources, no redirect chains, list still alphabetically sorted.
- Every redirect destination resolves to a page present in `navigation`.
- Links go live once this merges and the aggregation workflow republishes `docs-site`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added redirects for the graph memory usage command documentation.
  - Added redirects for the migration overview and migration guides, including Kùzu, Neo4j, RDF, RedisGraph, and SQL migration pages.
  - Supported both direct and `.html` URL formats for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->